### PR TITLE
Added a pypi publish step to our workflow

### DIFF
--- a/.github/workflows/build-and-test-mlbstatsapi.yml
+++ b/.github/workflows/build-and-test-mlbstatsapi.yml
@@ -22,7 +22,6 @@ jobs:
           python3 -m pip install --upgrade pytest
           python3 -m pip install --upgrade build
           python3 -m pip install --upgrade requests
-          python3 -m pip install --upgrade twine
       - name: Test with pytest
         run: |
           python3 -m pytest tests/*

--- a/.github/workflows/build-and-test-mlbstatsapi.yml
+++ b/.github/workflows/build-and-test-mlbstatsapi.yml
@@ -22,8 +22,18 @@ jobs:
           python3 -m pip install --upgrade pytest
           python3 -m pip install --upgrade build
           python3 -m pip install --upgrade requests
-          python3 -m build
-          python3 -m pip install .
+          python3 -m pip install --upgrade twine
       - name: Test with pytest
         run: |
           python3 -m pytest tests/*
+      - name: build and install
+        run: |
+          python3 -m build
+          python3 -m pip install .
+      - name: Publish a Python distribution to PyPI
+        if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "requests>=2"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "mlbstatsapi"
+name = "python-mlb-statsapi"
 version = "0.0.1"
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },


### PR DESCRIPTION
This PR adds a couple more steps to our workflow to do the following:

Build and install the package to the runner

Publish the package to PyPi

I'll add support in the future that only publish's tag releases 