### PR TITLE
Correctly grab pr url

### DIFF
--- a/.github/workflows/post-pr-url.yml
+++ b/.github/workflows/post-pr-url.yml
@@ -24,4 +24,4 @@ jobs:
           python3 -m pip install --upgrade slack_sdk          
       - name: Report PR url
         run: |
-          python3 ./.github/scripts/prslackbot.py ${{ secrets.SLACK_WEBCLIENT_TOKEN }} ${{ secrets.PR_CHANNEL }} github.event.pull_request.html_url
+          python3 ./.github/scripts/prslackbot.py ${{ secrets.SLACK_WEBCLIENT_TOKEN }} ${{ secrets.PR_CHANNEL }} ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Correctly grab pr URL.

Set cron testing to occur only once a day.

Report not just failures but also successes.