### PR TITLE
Correct cron branch to development

### DIFF
--- a/.github/scripts/prslackbot.py
+++ b/.github/scripts/prslackbot.py
@@ -6,8 +6,6 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 # get from environment variables
-SLACK_WEBCLIENT_TOKEN   = os.environ.get("SLACK_WEBCLIENT_TOKEN")
-CHANNEL                 = os.environ.get("CHANNEL")
 PR_URL                  = os.environ.get("PR_URL")
 PR_USER                 = os.environ.get("PR_USER")
 PR_USER_IMAGE           = os.environ.get("PR_USER_IMAGE")
@@ -28,6 +26,15 @@ def reportpullrequesturl(channel, slacktoken):
 
     # ID of channel you want to post message to
     channel_id = channel
+    
+    msg = []
+
+    for line in PR_BODY.splitlines():        
+        if line[:4] == "### ":
+            line = '*' + line[4:] + '*'
+        msg.append(line)
+    
+    msg = "\n".join(msg)
 
     try:
         # Call the conversations.list method using the WebClient
@@ -61,7 +68,7 @@ def reportpullrequesturl(channel, slacktoken):
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": f'*<{PR_URL}|#{PR_NUMBER} {PR_TITLE}>* \n{PR_BODY}'
+                                "text": f'*<{PR_URL}|#{PR_NUMBER} {PR_TITLE}>* \n{msg}'
                             }
                         },                        
                         {

--- a/.github/workflows/catch-and-report.yml
+++ b/.github/workflows/catch-and-report.yml
@@ -1,9 +1,9 @@
-name: Catch unexpected keyword arguments
+name: Report mlbstatsapi tests periodically
 
 on:
   schedule:
-    # Run every six hours
-    - cron:  '0 17,23 * * *'
+    # Run every day at 10:25 am and 4:25 pm PST
+    - cron:  '25 17,23 * * *'
 
 jobs:
   catch_errors_and_report:
@@ -15,14 +15,16 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@develop
+      - uses: actions/checkout@development
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip                    
+          python3 -m pip install --upgrade pip       
+          python3 -m pip install --upgrade pytest       
+          python3 -m pip install --upgrade requests      
           python3 -m pip install --upgrade slack_sdk          
       - name: Test and report
         run: |


### PR DESCRIPTION
### Why

Branch the actions cron job for testing our code periodically and reporting to slack is the old develop branch. Need to change this to our current development branch.

### What

- Uses development branch instead of develop
- Adds pip install for pytest and requests to match build and test actions job (runs same testing)

### Tests

Not tested and cant due to actions being actions. Works currently but uses wrong branch.

### Risk and impact

No risk and positive impact. If problem, nothing is impacted.

- Minimal / Normal / High

Minimal
