### PR TITLE
Fix get_schedule

### DIFF
--- a/mlbstatsapi/mlbapi.py
+++ b/mlbstatsapi/mlbapi.py
@@ -210,8 +210,9 @@ class Mlb:
         """     
         mlbdata = self._mlb_adapter_v1.get(endpoint=f"schedule?sportId=1&startDate={startdate}&endDate={enddate}") # Get schedule
 
-        # if mlbdata is not empty, and 'dates' key is in mlbdata.data and mlbdata.data['dates] is not empty list
-        if ('dates' in mlbdata.data and mlbdata.data['dates']):
+        # if mlbdata is not empty, and 'dates' key is in mlbdata.data and mlbdata.data['dates] can sometimes be an empty list
+        # when there are no scheduled game for the date(s). Only check for existance 'dates' key for this reason.
+        if ('dates' in mlbdata.data):
             return Schedule(**mlbdata.data)
 
     def get_schedule_today(self) -> Union[Schedule, None]:        


### PR DESCRIPTION
### Why

Periodic test failed on get_schedule. It was checking for the key 'dates' to be a not empty list while when there are no games for the date, the key 'dates' indeed does return an empty list.

### What

get_schedule Now only checks for the existence of the key 'dates' instead of also checking if 'dates' is a non empty list.

### Tests

Tests passed, all green.

### Risk and impact

Should be minimal risk and impact. Only issue is not handling an empty get games object incorrectly but currently we handle that correctly. 

- Minimal / Normal / High

Normal
