### PR TITLE
Adding builds for test, prd, and pushes

### DIFF
--- a/.github/workflows/build-and-test-mlbstatsapi-prd.yml
+++ b/.github/workflows/build-and-test-mlbstatsapi-prd.yml
@@ -1,0 +1,37 @@
+﻿name: Python Build MLBstats API 
+
+on:
+  push:
+    branches:
+     - main
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pytest
+          python3 -m pip install --upgrade build
+          python3 -m pip install --upgrade requests
+      - name: Test with pytest
+        run: |
+          python3 -m pytest tests/*
+      - name: build and install
+        run: |
+          python3 -m build
+          python3 -m pip install .
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-and-test-mlbstatsapi-test.yml
+++ b/.github/workflows/build-and-test-mlbstatsapi-test.yml
@@ -1,6 +1,9 @@
 name: Python Build MLBstats API 
 
-on: [push]
+on:
+  push:
+   branches:
+     - development
 
 jobs:
   build:
@@ -29,10 +32,11 @@ jobs:
         run: |
           python3 -m build
           python3 -m pip install .
-      - name: Publish a Python distribution to PyPI
-        #if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+      - name: Publish package to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,34 @@
+﻿name: Python Build MLBstats API 
+
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'development'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pytest
+          python3 -m pip install --upgrade build
+          python3 -m pip install --upgrade requests
+      - name: Test with pytest
+        run: |
+          python3 -m pytest tests/*
+      - name: build and install
+        run: |
+          python3 -m build
+          python3 -m pip install .


### PR DESCRIPTION
### Why
Builds weren't responding right to PRs. This will build and push to pypi test for merges into development, and to production when we start merging to main.

We should however add some more logic in the future where only tagged builds are pushed to pypi 

### What
Created three different workflows for each branch

### Tests
A good guess 

### Risk and impact
- Minimal
