### PR TITLE
Fix hitdata

### DIFF
--- a/mlbstatsapi/models/game/livedata/plays/play/playevent/attributes.py
+++ b/mlbstatsapi/models/game/livedata/plays/play/playevent/attributes.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from dataclasses import dataclass
 
 @dataclass
@@ -46,13 +46,14 @@ class HitData:
     coordinates : HitCoordinate
         Hit coordinates
     """
-    launchspeed: float
-    launchangle: int
-    totaldistance: int
+    
     trajectory: str
     hardness: str
     location: str
     coordinates: HitCoordinate
+    launchspeed: Optional[float] = None
+    launchangle: Optional[int] = None
+    totaldistance: Optional[int] = None
 
     def __post_init__(self):
         self.coordinates = HitCoordinate(**self.coordinates)


### PR DESCRIPTION
### Why

HitData broke on Thursdays world series game. This fixes that.

### What

Set three attributes of hitdata to optional to accommodate the error caused by Thursdays WS game.

### Tests

Passes unit tests as well as on Thursdays game. 

### Risk and impact

Minimal

What is the impact if something does go wrong with this PR?

None
