### PR TITLE
Changing URL to simple

### DIFF
--- a/.github/workflows/build-and-test-mlbstatsapi-test.yml
+++ b/.github/workflows/build-and-test-mlbstatsapi-test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository_url: https://test.pypi.org/simple/
 
 
 


### PR DESCRIPTION
### Why
Our development branch should be sent to the pypi test simple index

### What
changed test URL to push package to simple

### Tests
This PR is the test :P

### Risk and impact

What is the risk level of the change and **why?**

- Minimal / Normal / High

What is the impact if something does go wrong with this PR?
