### PR TITLE
Game by date

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Use player.id and stat types and groups to return a stats dictionary
 Print season hitting stats
 ```
 >>> for attribute, value in season_hitting_stat.stat.__dict__.items():
->>>     print(attribute, value)
+...     print(attribute, value)
 >>>
 ```
 #### Team stats
@@ -127,9 +127,9 @@ advanced_hitting = stats['hitting']['seasonadvanced']
 Print season and seasonadvanced stats
 ```
 >>> for attribute, value in season_hitting.stat.__dict__.items():
->>>     print(attribute, value)
+...     print(attribute, value)
 >>>
->>> for attribute, value in advanced_hitting.stat.__dict__.items():
+... for attribute, value in advanced_hitting.stat.__dict__.items():
 >>>     print(attribute, value)
 ```
 
@@ -196,7 +196,24 @@ season should be 2018
 assertEqual(stats[season_hitting.season == 2018)
 assertEqual(stats[advanced_hitting.season == 2018)
 ```
-
+### Schedule Examples
+Get a schedule for given date
+```
+>>> mlb = mlbstatsapi.Mlb()
+>>> schedule = mlb.get_schedule_date('2022-10-13')
+```
+Get ScheduleDates from Schedule
+```
+dates = schedule.dates
+```
+Print Game status and Home and Away Teams
+```
+>>> for date in dates:
+...     for game in date.games:
+...             print(game.status)
+...             print(game.teams.home)
+...             print(game.teams.away)
+```
 ### Game Examples
 
 ### People Examples
@@ -206,13 +223,14 @@ Get all Players for a given sport id
 >>> sport_id = mlb.get_sport_id()
 >>> players = mlb.get_players(sport_id=sport_id)
 >>> for player in players:
->>>     print(player.id)
+...     print(player.id)
 ```
 Get a player id
 ```
 >>> player_id = mlb.get_player_id("Ty France")
 >>> print(player_id[0])
 ```
+
 
 ### Team Examples
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,14 @@ Get a player id
 >>> print(player_id[0])
 ```
 
-
 ### Team Examples
-
+Get a Team
+```
+>>> mlb = mlbstatsapi.Mlb()
+>>> team_id = mlb.get_team_id("Seattle Mariners")
+>>> team = mlb.get_team(team_id)
+>>> print(team.id)
+>>> print(team.name)
+```
 ### Venue Examples
 

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -465,10 +465,12 @@ class Mlb:
 
         Parameters
         ----------
-        start_date : str 
+        date : str 
             start date, 'yyyy-mm-dd'
         end_date : str
             end date, 'yyyy-mm-dd'
+        spord_id : int
+            spord id of schedule defaults to 1
 
         Returns
         -------
@@ -650,10 +652,12 @@ class Mlb:
 
         Parameters
         ----------
-        date : str 'yyyy-mm-dd'
-            Date
-        abstract_game_state : str
-            Game status type to search for, abstract_game_state
+        date : str 
+            start date, 'yyyy-mm-dd'
+        end_date : str
+            end date, 'yyyy-mm-dd'
+        spord_id : int
+            spord id of schedule defaults to 1
 
         Returns
         -------
@@ -693,96 +697,6 @@ class Mlb:
                    game_ids.append(game.gamepk)
 
         return game_ids
-
-
-    def get_todays_game_ids(self, abstract_game_state: str = None) -> List[int]:
-        """
-        return game ids for todays date
-
-        Parameters
-        ----------
-        abstract_game_state : str
-            Game status type to search for, abstract_game_state
-
-        Returns
-        -------
-        list of ints
-            returns a list of game ids
-
-        See Also
-        --------
-        Mlb.get_game_play_by_play : return play by play data for a game
-        Mlb.get_game_line_score : return a linescore for a game
-        Mlb.get_tomorrows_game_ids : return a list of game ids for today
-        Mlb.get_yesterdays_game_ids : return a list of game ids from yesterday
-        Mlb.get_game : return a specific game from game id
-
-        Examples
-        --------
-        >>> mlb = Mlb()
-        >>> mlb.get_todays_game_ids()
-        [662242, 662243, 662244]
-        """
-
-        todays_date = datetime.date.today()
-        todays_games = self.get_game_ids(todays_date.strftime("%Y-%m-%d"), abstract_game_state)
-        return todays_games
-
-    def get_tomorrows_game_ids(self) -> List[int]:
-        """
-        return game ids for tomorrows date
-
-        Returns
-        -------
-        list of ints
-            returns a list of game ids
-
-        See Also
-        --------
-        Mlb.get_game_play_by_play : return play by play data for a game
-        Mlb.get_game_line_score : return a linescore for a game
-        Mlb.get_todays_game_ids : return a list of game ids for today
-        Mlb.get_yesterdays_game_ids : return a list of game ids from yesterday
-        Mlb.get_game : return a specific game from game id
-
-        Examples
-        --------
-        >>> mlb = Mlb()
-        >>> mlb.get_tomorrows_game_ids()
-        [662242, 662243, 662244]
-        """
-
-        tomorrows_date = datetime.date.today() + datetime.timedelta(days=1)
-        tomorrows_games = self.get_game_ids(tomorrows_date.strftime("%Y-%m-%d"))
-        return tomorrows_games
-
-    def get_yesterdays_game_ids(self) -> List[int]:
-        """
-        return game ids for yesterdays date
-
-        Returns
-        -------
-        list of ints
-            returns a list of game ids
-
-        See Also
-        --------
-        Mlb.get_game_play_by_play : return play by play data for a game
-        Mlb.get_game_line_score : return a linescore for a game
-        Mlb.get_todays_game_ids : return a list of game ids for today
-        Mlb.get_yesterdays_game_ids : return a list of game ids from yesterday
-        Mlb.get_game : return a specific game from game id
-
-        Examples
-        --------
-        >>> mlb = Mlb()
-        >>> mlb.get_yesterdays_game_ids()
-        [662242, 662243, 662244]
-        """
-
-        yesterdays_date = datetime.date.today() - datetime.timedelta(days=1)
-        yesterdays_games = self.get_game_ids(yesterdays_date.strftime("%Y-%m-%d"))
-        return yesterdays_games
 
     def get_venue(self, venue_id) -> Union[Venue, None]:
         """

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -10,7 +10,7 @@ from mlbstatsapi.models.leagues import League
 from mlbstatsapi.models.game import Game, Plays, Linescore, BoxScore
 from mlbstatsapi.models.venues import Venue
 from mlbstatsapi.models.divisions import Division
-from mlbstatsapi.models.schedules import Schedule
+from mlbstatsapi.models.schedules import Schedule, ScheduleGames
 from mlbstatsapi.models.attendances import Attendance
 from mlbstatsapi.models.stats import Stat
 from mlbstatsapi.models.seasons import Season
@@ -398,7 +398,7 @@ class Mlb:
 
         return coaches
 
-    def get_schedule(self, start_date: str = None, end_date: str = None, sport_id: int = 1) -> Union[Schedule, None]:
+    def get_schedule(self, date: str, end_date: str = None, sport_id: int = 1, **params) -> Union[Schedule, None]:
         """
         return the schedule created from the included params.
 
@@ -419,13 +419,12 @@ class Mlb:
         Returns
         -------
         Schedule
-            returns the Schedule for the date
+            returns the Schedule for the dates
 
         See Also
         --------
-        Mlb.get_schedule_today : Return schedule for today
-        Mlb.get_schedule_date : Return schedule for date
-        Mlb.get_schedule_date_range : Return schedule between date
+        Mlb.get_scheduled_games_by_date : return a list of scheduledgames
+
 
         Examples
         --------
@@ -436,10 +435,15 @@ class Mlb:
         """
 
         # default to today if not set
-        start_date = datetime.date.today().strftime("%Y-%m-%d") if start_date is None else start_date
-        end_date = datetime.date.today().strftime("%Y-%m-%d") if end_date is None else end_date
+        if not end_date:
+            params['endDate'] = date
+            params['startDate'] = date
+        else:
+            params['startDate'] = date
+            params['endDate'] = end_date
 
-        params = {'sportId': sport_id, 'startDate': start_date, 'endDate': end_date}
+        params['sportId'] = sport_id
+    
 
         mlb_data = self._mlb_adapter_v1.get(endpoint='schedule', ep_params=params)
         if 400 <= mlb_data.status_code <= 499:
@@ -452,96 +456,61 @@ class Mlb:
         if 'dates' in mlb_data.data and mlb_data.data['dates']:
             return Schedule(**mlb_data.data)
 
-    def get_schedule_today(self, sport_id: int = 1) -> Union[Schedule, None]:        
+    def get_scheduled_games_by_date(self, date: str, 
+                                    end_date: str = None,
+                                    sport_id: int = 1, 
+                                    abstract_game_state: str = None, **params) -> List[ScheduleGames]:
         """
-        return the schedule for today
+        return game ids for a specific date and game status
 
         Parameters
         ----------
-        spord_id : int
-            sport id of the schedule
+        start_date : str 
+            start date, 'yyyy-mm-dd'
+        end_date : str
+            end date, 'yyyy-mm-dd'
+        abstract_game_state : str
+            Game status type to search for, abstract_game_state
 
         Returns
         -------
-        Schedule
-            returns todays schedule
+        list of ScheduleGames 
+            returns a list of matching game ids
 
         See Also
         --------
-        Mlb.get_schedule : Return schedule for dates
-        Mlb.get_schedule_date : Return schedule for date
-        Mlb.get_schedule_date_range : Return schedule between date
-        
-        Examples
-        --------
-        >>> mlb = Mlb()
-        >>> mlb.get_schedule_today()
-        Schedule
-        """
-
-        return self.get_schedule(sport_id=sport_id)
-
-    def get_schedule_date(self, date, sport_id: int = 1) -> Union[Schedule, None]:
-        """
-        return the schedule for a specific date
-
-        Parameters
-        ----------
-        date : str "yyyy-mm-dd"
-            Date
-        sport_id : int
-            sport id of the schedule
-
-        Returns
-        -------
-        Schedule
-            returns the schedule for given date
-
-        See Also
-        --------
-        Mlb.get_schedule : Return schedule for dates
-        Mlb.get_schedule_today : Return schedule for today
-        Mlb.get_schedule_date_range : Return schedule between date
-        
-        Examples
-        --------
-        >>> mlb = Mlb()
-        >>> mlb.get_schedule_date("2022-07-03")
-        Schedule
-        """
-
-        return self.get_schedule(start_date=date, end_date=date, sport_id=sport_id)
-
-    def get_schedule_date_range(self, start_date: str, end_date: str, sport_id: int = 1) -> Union[Schedule, None]:
-        """
-        return the schedule for a range of dates
-
-        Parameters
-        ----------
-        start_date : str "yyyy-mm-dd"
-            Start date
-        end_date : str "yyyy-mm-dd"
-            End date
-        sport_id : int
-            sport id of the schedule
-
-        Returns
-        -------
-        Schedule
-
-        See Also
-        --------
-        Mlb.get_schedule : Return schedule for dates
-        Mlb.get_schedule_today : Return schedule for today
-        Mlb.get_schedule_date : Return schedule for date
+        Mlb.get_game_play_by_play : return play by play data for a game
+        Mlb.get_game_line_score : return a linescore for a game
+        Mlb.get_todays_game_ids : return a list of game ids for today
+        Mlb.get_game : return a specific game from game id
 
         Examples
         --------
         >>> mlb = Mlb()
-        >>> mlb.get_schedule_date_range(start_date="2021-08-01", end_date="2021-08-11")
+        >>> mlb.get_game_ids()
         """
+        # default to today if not set
+        if not end_date:
+            params['endDate'] = date
+            params['startDate'] = date
+        else:
+            params['startDate'] = date
+            params['endDate'] = end_date
 
-        return self.get_schedule(start_date=start_date, end_date=end_date, sport_id=sport_id)
+        params['sportId'] = sport_id
+
+        games = []
+
+        mlb_data = self._mlb_adapter_v1.get(endpoint='schedule', ep_params=params)
+        if 400 <= mlb_data.status_code <= 499:
+            return []
+
+        if 'dates' in mlb_data.data and mlb_data.data['dates']:
+            for date in mlb_data.data['dates']:
+               for game in date['games']:
+                   games.append(ScheduleGames(**game))
+
+        return games
 
     def get_game(self, game_id) -> Union[Game, None]:
         """
@@ -673,7 +642,10 @@ class Mlb:
         if 'teams' in mlb_data.data and mlb_data.data['teams']:
             return BoxScore(**mlb_data.data)
 
-    def get_game_ids(self, date: str, abstract_game_state: str = None) -> List[int]:
+ 
+
+
+    def get_game_ids(self, start_date: str, end_date: str = None, abstract_game_state: str = None) -> List[int]:
         """
         return game ids for a specific date and game status
 
@@ -701,8 +673,10 @@ class Mlb:
         >>> mlb = Mlb()
         >>> mlb.get_game_ids()
         """
+        if not start_date:
+            end_date = start_date
 
-        scheduled_games = self.get_schedule(date, date)
+        scheduled_games = self.get_schedule(date=start_date, end_date=end_date)
         games_ids = []
 
         # TODO Can we clean up this logic? lol my attempt isn't much better, it's still confusing
@@ -1508,6 +1482,52 @@ class Mlb:
         season : str
             Insert year to return team stats for a particular season, season=2018
 
+        Stats
+        -----
+        season : str
+            a season stat, supports stat groups hitting, pitching, fielding, and catching
+        seasonAdvanced : str
+            a seasonAdvanced stat, supports stat groups hitting, pitching, fielding, and catching
+        career : str
+            a career stat, supports stat groups hitting, pitching, fielding, and catching
+        winLoss : str
+            a winLoss stat, supports stat groups hitting, pitching
+        winLossPlayoffs : str
+            a winloss playoff stat, supports stat groups hitting, pitching
+        homeAndAway : str
+            a homeandaway stat, supports stat groups hitting, pitching
+        homeAndAwayPlayoffs : str
+            a homeandaway playoffs stat, supports stat groups hitting, pitching
+        careerRegularSeason : str
+            a career stat, supports stat groups hitting, pitching
+        careerPlayoffs : str
+            a career playoff stat, supports stat groups hitting, pitching
+        statsSingleSeason : str 
+            a careeer playoff stat, supports stat groups hitting, pitching
+        careerAdvanced : str
+            a careerAdvanced  stat, supports stat groups hitting, pitching
+        yearByYear : str
+            a yearbyyear  stat, supports stat groups hitting, pitching
+        yearByYearPlayoffs : str
+            a yearbyyear playoff stat, supports stat groups hitting, pitching
+        opponentsFaced : str
+            a opponentsFace stat, supports stat groups hitting, pitching
+        sabermetrics : str
+            a sabermetrics stat
+        gameLog : str
+            a gamelog stat, supports stat groups hitting, pitching
+
+        Groups
+        ------
+        hitting : str
+            stat group hitting
+        pitching : str
+            stat group pitching
+        fielding : str
+            stat group fielding
+        catching : str
+            stat group catching
+
         Returns
         -------
         dict 
@@ -1558,8 +1578,8 @@ class Mlb:
         season : str
             Insert year to return team stats for a particular season, season=2018
         
-        Stat Types
-        __________
+        Stats
+        -----
         season : str
             a season stat, supports stat groups hitting, pitching, fielding, and catching
         seasonAdvanced : str
@@ -1592,6 +1612,17 @@ class Mlb:
             a sabermetrics stat
         gameLog : str
             a gamelog stat, supports stat groups hitting, pitching
+
+        Groups
+        ------
+        hitting : str
+            stat group hitting
+        pitching : str
+            stat group pitching
+        fielding : str
+            stat group fielding
+        catching : str
+            stat group catching
 
         Returns
         -------
@@ -1639,8 +1670,8 @@ class Mlb:
         season : str
             Insert year to return team stats for a particular season, season=2018
 
-        Stat Types
-        __________
+        Stats
+        -----
         season : str
             a season stat, supports stat groups hitting, pitching, fielding, and catching
         seasonAdvanced : str
@@ -1674,6 +1705,16 @@ class Mlb:
         gameLog : str
             a gamelog stat, supports stat groups hitting, pitching
 
+        Groups
+        ------
+        hitting : str
+            stat group hitting
+        pitching : str
+            stat group pitching
+        fielding : str
+            stat group fielding
+        catching : str
+            stat group catching
         Returns
         -------
         splits : dict

--- a/mlbstatsapi/models/schedules/__init__.py
+++ b/mlbstatsapi/models/schedules/__init__.py
@@ -1,1 +1,2 @@
 from .schedule import Schedule
+from .attributes import ScheduleGames

--- a/mlbstatsapi/models/schedules/attributes.py
+++ b/mlbstatsapi/models/schedules/attributes.py
@@ -138,8 +138,6 @@ class ScheduleGames:
     season: str
     gamedate: str
     officialdate: str
-    status: Union[GameStatus, dict]
-    teams: Union[ScheduleHomeAndAway, dict]
     venue: Venue
     content: dict
     gamenumber: int
@@ -158,6 +156,8 @@ class ScheduleGames:
     recordsource: str
     ifnecessary: str
     ifnecessarydescription: str
+    status: Union[GameStatus, dict] = field(default_factory=dict)
+    teams: Union[ScheduleHomeAndAway, dict] = field(default_factory=dict)
     description: Optional[str] = None
     inningbreaklength: Optional[int] = None
     rescheduledate: Optional[str] = None
@@ -167,8 +167,8 @@ class ScheduleGames:
     istie: Optional[bool] = None
 
     def __post_init__(self):
-        self.status = GameStatus(**self.status)
-        self.teams = ScheduleHomeAndAway(**self.teams)
+        self.status = GameStatus(**self.status) if self.status else self.status
+        self.teams = ScheduleHomeAndAway(**self.teams) if self.teams else self.teams
 
 
 @dataclass
@@ -203,4 +203,4 @@ class ScheduleDates:
     games: List[ScheduleGames] = field(default_factory=list)
 
     def __post_init__(self):
-        self.games = [ScheduleGames(**game) for game in self.games if self.games]
+        self.games = [ScheduleGames(**game) for game in self.games ] if self.games else self.games

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },
   { name="Kristian Nilssen", email="krinilssen@gmail.com" },

--- a/tests/external_tests/mlb/test_mlb.py
+++ b/tests/external_tests/mlb/test_mlb.py
@@ -307,10 +307,6 @@ class TestMlbGetGame(unittest.TestCase):
         boxscore = self.mlb.get_game_box_score(662242)
         self.assertIsInstance(boxscore, BoxScore)
 
-    def test_get_todays_games_id(self):
-        todaysGames = self.mlb.get_todays_game_ids()
-        self.assertIsInstance(todaysGames, List)
-
     def test_get_attendance(self):
         params = {'season': 2022}
         attendance_team_away = self.mlb.get_attendance(team_id=113)

--- a/tests/external_tests/schedule/test_schedule.py
+++ b/tests/external_tests/schedule/test_schedule.py
@@ -7,7 +7,7 @@ class TestSchedule(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.mlb = Mlb()
-        cls.schedule = cls.mlb.get_schedule_date('2022-10-07')
+        cls.schedule = cls.mlb.get_schedule(date='2022-10-07')
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/tests/mock_tests/mock_json/schedule/schedule_date.json
+++ b/tests/mock_tests/mock_json/schedule/schedule_date.json
@@ -1,0 +1,707 @@
+﻿{
+    "copyright": "Copyright 2022 MLB Advanced Media, L.P.  Use of any content on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt",
+    "totalItems": 9,
+    "totalEvents": 0,
+    "totalGames": 9,
+    "totalGamesInProgress": 0,
+    "dates": [
+      {
+        "date": "2022-04-07",
+        "totalItems": 9,
+        "totalEvents": 0,
+        "totalGames": 9,
+        "totalGamesInProgress": 0,
+        "games": [
+          {
+            "gamePk": 663178,
+            "link": "/api/v1.1/game/663178/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T18:20:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 4,
+                "team": {
+                  "id": 158,
+                  "name": "Milwaukee Brewers",
+                  "link": "/api/v1/teams/158"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 5,
+                "team": {
+                  "id": 112,
+                  "name": "Chicago Cubs",
+                  "link": "/api/v1/teams/112"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 17,
+              "name": "Wrigley Field",
+              "link": "/api/v1/venues/17"
+            },
+            "content": {
+              "link": "/api/v1/game/663178/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-663178-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "day",
+            "description": "Cubs home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 3,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 662766,
+            "link": "/api/v1.1/game/662766/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T20:10:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 1,
+                "team": {
+                  "id": 114,
+                  "name": "Cleveland Guardians",
+                  "link": "/api/v1/teams/114"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 3,
+                "team": {
+                  "id": 118,
+                  "name": "Kansas City Royals",
+                  "link": "/api/v1/teams/118"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 7,
+              "name": "Kauffman Stadium",
+              "link": "/api/v1/venues/7"
+            },
+            "content": {
+              "link": "/api/v1/game/662766/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-662766-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "day",
+            "description": "Royals home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 662021,
+            "link": "/api/v1.1/game/662021/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T20:15:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 0,
+                "team": {
+                  "id": 134,
+                  "name": "Pittsburgh Pirates",
+                  "link": "/api/v1/teams/134"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 9,
+                "team": {
+                  "id": 138,
+                  "name": "St. Louis Cardinals",
+                  "link": "/api/v1/teams/138"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 2889,
+              "name": "Busch Stadium",
+              "link": "/api/v1/venues/2889"
+            },
+            "content": {
+              "link": "/api/v1/game/662021/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-662021-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "day",
+            "description": "Cardinals home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 3,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 662571,
+            "link": "/api/v1.1/game/662571/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T23:05:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 5,
+                "team": {
+                  "id": 121,
+                  "name": "New York Mets",
+                  "link": "/api/v1/teams/121"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 1,
+                "team": {
+                  "id": 120,
+                  "name": "Washington Nationals",
+                  "link": "/api/v1/teams/120"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 3309,
+              "name": "Nationals Park",
+              "link": "/api/v1/venues/3309"
+            },
+            "content": {
+              "link": "/api/v1/game/662571/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-662571-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "night",
+            "description": "Nationals home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 661577,
+            "link": "/api/v1.1/game/661577/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-08T00:08:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 6,
+                "team": {
+                  "id": 113,
+                  "name": "Cincinnati Reds",
+                  "link": "/api/v1/teams/113"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 3,
+                "team": {
+                  "id": 144,
+                  "name": "Atlanta Braves",
+                  "link": "/api/v1/teams/144"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 4705,
+              "name": "Truist Park",
+              "link": "/api/v1/venues/4705"
+            },
+            "content": {
+              "link": "/api/v1/game/661577/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-661577-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "night",
+            "description": "Braves home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 145,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 661042,
+            "link": "/api/v1.1/game/661042/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-08T01:38:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 3,
+                "team": {
+                  "id": 117,
+                  "name": "Houston Astros",
+                  "link": "/api/v1/teams/117"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 1,
+                "team": {
+                  "id": 108,
+                  "name": "Los Angeles Angels",
+                  "link": "/api/v1/teams/108"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 1,
+              "name": "Angel Stadium",
+              "link": "/api/v1/venues/1"
+            },
+            "content": {
+              "link": "/api/v1/game/661042/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-661042-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "night",
+            "description": "Angels home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 663418,
+            "link": "/api/v1.1/game/663418/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-08T01:40:00Z",
+            "officialDate": "2022-04-07",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "F",
+              "detailedState": "Final",
+              "statusCode": "F",
+              "startTimeTBD": false,
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "score": 2,
+                "team": {
+                  "id": 135,
+                  "name": "San Diego Padres",
+                  "link": "/api/v1/teams/135"
+                },
+                "isWinner": false,
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "score": 4,
+                "team": {
+                  "id": 109,
+                  "name": "Arizona Diamondbacks",
+                  "link": "/api/v1/teams/109"
+                },
+                "isWinner": true,
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 15,
+              "name": "Chase Field",
+              "link": "/api/v1/venues/15"
+            },
+            "content": {
+              "link": "/api/v1/game/663418/content"
+            },
+            "isTie": false,
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-663418-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "night",
+            "description": "D-backs home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 661333,
+            "link": "/api/v1.1/game/661333/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T17:05:00Z",
+            "officialDate": "2022-04-08",
+            "rescheduleDate": "2022-04-08T17:05:00Z",
+            "rescheduleGameDate": "2022-04-08",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "D",
+              "detailedState": "Postponed",
+              "statusCode": "DI",
+              "startTimeTBD": false,
+              "reason": "Inclement Weather",
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "team": {
+                  "id": 111,
+                  "name": "Boston Red Sox",
+                  "link": "/api/v1/teams/111"
+                },
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "team": {
+                  "id": 147,
+                  "name": "New York Yankees",
+                  "link": "/api/v1/teams/147"
+                },
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 3313,
+              "name": "Yankee Stadium",
+              "link": "/api/v1/venues/3313"
+            },
+            "content": {
+              "link": "/api/v1/game/661333/content"
+            },
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-661333-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "day",
+            "description": "Yankees home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 145,
+            "gamesInSeries": 3,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          },
+          {
+            "gamePk": 661750,
+            "link": "/api/v1.1/game/661750/feed/live",
+            "gameType": "R",
+            "season": "2022",
+            "gameDate": "2022-04-07T20:10:00Z",
+            "officialDate": "2022-04-08",
+            "rescheduleDate": "2022-04-08T20:10:00Z",
+            "rescheduleGameDate": "2022-04-08",
+            "status": {
+              "abstractGameState": "Final",
+              "codedGameState": "D",
+              "detailedState": "Postponed",
+              "statusCode": "DI",
+              "startTimeTBD": false,
+              "reason": "Inclement Weather",
+              "abstractGameCode": "F"
+            },
+            "teams": {
+              "away": {
+                "leagueRecord": {
+                  "wins": 1,
+                  "losses": 0,
+                  "pct": "1.000"
+                },
+                "team": {
+                  "id": 136,
+                  "name": "Seattle Mariners",
+                  "link": "/api/v1/teams/136"
+                },
+                "splitSquad": false,
+                "seriesNumber": 1
+              },
+              "home": {
+                "leagueRecord": {
+                  "wins": 0,
+                  "losses": 1,
+                  "pct": ".000"
+                },
+                "team": {
+                  "id": 142,
+                  "name": "Minnesota Twins",
+                  "link": "/api/v1/teams/142"
+                },
+                "splitSquad": false,
+                "seriesNumber": 1
+              }
+            },
+            "venue": {
+              "id": 3312,
+              "name": "Target Field",
+              "link": "/api/v1/venues/3312"
+            },
+            "content": {
+              "link": "/api/v1/game/661750/content"
+            },
+            "gameNumber": 1,
+            "publicFacing": true,
+            "doubleHeader": "N",
+            "gamedayType": "P",
+            "tiebreaker": "N",
+            "calendarEventID": "14-661750-2022-04-07",
+            "seasonDisplay": "2022",
+            "dayNight": "day",
+            "description": "Twins home opener",
+            "scheduledInnings": 9,
+            "reverseHomeAwayStatus": false,
+            "inningBreakLength": 120,
+            "gamesInSeries": 4,
+            "seriesGameNumber": 1,
+            "seriesDescription": "Regular Season",
+            "recordSource": "S",
+            "ifNecessary": "N",
+            "ifNecessaryDescription": "Normal Game"
+          }
+        ],
+        "events": []
+      }
+    ]
+  }

--- a/tests/mock_tests/mock_json/schedule/schedule_start_end_date.json
+++ b/tests/mock_tests/mock_json/schedule/schedule_start_end_date.json
@@ -1,0 +1,587 @@
+﻿{
+  "copyright": "Copyright 2022 MLB Advanced Media, L.P.  Use of any content on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt",
+  "totalItems": 8,
+  "totalEvents": 0,
+  "totalGames": 8,
+  "totalGamesInProgress": 0,
+  "dates": [
+    {
+      "date": "2022-10-11",
+      "totalItems": 4,
+      "totalEvents": 0,
+      "totalGames": 4,
+      "totalGamesInProgress": 0,
+      "games": [
+        {
+          "gamePk": 715743,
+          "link": "/api/v1.1/game/715743/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-11T17:07:00Z",
+          "officialDate": "2022-10-11",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 0,
+                "pct": "1.000"
+              },
+              "score": 7,
+              "team": {
+                "id": 143,
+                "name": "Philadelphia Phillies",
+                "link": "/api/v1/teams/143"
+              },
+              "isWinner": true,
+              "splitSquad": false,
+              "seriesNumber": 4
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 0,
+                "losses": 1,
+                "pct": ".000"
+              },
+              "score": 6,
+              "team": {
+                "id": 144,
+                "name": "Atlanta Braves",
+                "link": "/api/v1/teams/144"
+              },
+              "isWinner": false,
+              "splitSquad": false,
+              "seriesNumber": 4
+            }
+          },
+          "venue": {
+            "id": 4705,
+            "name": "Truist Park",
+            "link": "/api/v1/venues/4705"
+          },
+          "content": {
+            "link": "/api/v1/game/715743/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715743-2022-10-11",
+          "seasonDisplay": "2022",
+          "dayNight": "day",
+          "description": "NLDS Game 1",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 1,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        },
+        {
+          "gamePk": 715758,
+          "link": "/api/v1.1/game/715758/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-11T19:37:00Z",
+          "officialDate": "2022-10-11",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 0,
+                "losses": 1,
+                "pct": ".000"
+              },
+              "score": 7,
+              "team": {
+                "id": 136,
+                "name": "Seattle Mariners",
+                "link": "/api/v1/teams/136"
+              },
+              "isWinner": false,
+              "splitSquad": false,
+              "seriesNumber": 1
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 0,
+                "pct": "1.000"
+              },
+              "score": 8,
+              "team": {
+                "id": 117,
+                "name": "Houston Astros",
+                "link": "/api/v1/teams/117"
+              },
+              "isWinner": true,
+              "splitSquad": false,
+              "seriesNumber": 1
+            }
+          },
+          "venue": {
+            "id": 2392,
+            "name": "Minute Maid Park",
+            "link": "/api/v1/venues/2392"
+          },
+          "content": {
+            "link": "/api/v1/game/715758/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715758-2022-10-11",
+          "seasonDisplay": "2022",
+          "dayNight": "day",
+          "description": "ALDS Game 1",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 1,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        },
+        {
+          "gamePk": 715753,
+          "link": "/api/v1.1/game/715753/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-11T23:37:00Z",
+          "officialDate": "2022-10-11",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {},
+          "venue": {
+            "id": 3313,
+            "name": "Yankee Stadium",
+            "link": "/api/v1/venues/3313"
+          },
+          "content": {
+            "link": "/api/v1/game/715753/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715753-2022-10-11",
+          "seasonDisplay": "2022",
+          "dayNight": "night",
+          "description": "ALDS Game 1",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 1,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        },
+        {
+          "gamePk": 715748,
+          "link": "/api/v1.1/game/715748/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-12T01:37:00Z",
+          "officialDate": "2022-10-11",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {},
+          "venue": {
+            "id": 22,
+            "name": "Dodger Stadium",
+            "link": "/api/v1/venues/22"
+          },
+          "content": {
+            "link": "/api/v1/game/715748/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715748-2022-10-11",
+          "seasonDisplay": "2022",
+          "dayNight": "night",
+          "description": "NLDS Game 1",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 1,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        }
+      ],
+      "events": []
+    },
+    {
+      "date": "2022-10-12",
+      "totalItems": 2,
+      "totalEvents": 0,
+      "totalGames": 2,
+      "totalGamesInProgress": 0,
+      "games": [
+        {
+          "gamePk": 715742,
+          "link": "/api/v1.1/game/715742/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-12T20:35:00Z",
+          "officialDate": "2022-10-12",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "score": 0,
+              "team": {
+                "id": 143,
+                "name": "Philadelphia Phillies",
+                "link": "/api/v1/teams/143"
+              },
+              "isWinner": false,
+              "splitSquad": false,
+              "seriesNumber": 4
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "score": 3,
+              "team": {
+                "id": 144,
+                "name": "Atlanta Braves",
+                "link": "/api/v1/teams/144"
+              },
+              "isWinner": true,
+              "splitSquad": false,
+              "seriesNumber": 4
+            }
+          },
+          "venue": {
+            "id": 4705,
+            "name": "Truist Park",
+            "link": "/api/v1/venues/4705"
+          },
+          "content": {
+            "link": "/api/v1/game/715742/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715742-2022-10-12",
+          "seasonDisplay": "2022",
+          "dayNight": "day",
+          "description": "NLDS Game 2",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 2,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        },
+        {
+          "gamePk": 715747,
+          "link": "/api/v1.1/game/715747/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-13T00:37:00Z",
+          "officialDate": "2022-10-12",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "score": 5,
+              "team": {
+                "id": 135,
+                "name": "San Diego Padres",
+                "link": "/api/v1/teams/135"
+              },
+              "isWinner": true,
+              "splitSquad": false,
+              "seriesNumber": 3
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "score": 3,
+              "team": {
+                "id": 119,
+                "name": "Los Angeles Dodgers",
+                "link": "/api/v1/teams/119"
+              },
+              "isWinner": false,
+              "splitSquad": false,
+              "seriesNumber": 3
+            }
+          },
+          "venue": {
+            "id": 22,
+            "name": "Dodger Stadium",
+            "link": "/api/v1/venues/22"
+          },
+          "content": {
+            "link": "/api/v1/game/715747/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715747-2022-10-12",
+          "seasonDisplay": "2022",
+          "dayNight": "night",
+          "description": "NLDS Game 2",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 2,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        }
+      ],
+      "events": []
+    },
+    {
+      "date": "2022-10-13",
+      "totalItems": 2,
+      "totalEvents": 0,
+      "totalGames": 2,
+      "totalGamesInProgress": 0,
+      "games": [
+        {
+          "gamePk": 715757,
+          "link": "/api/v1.1/game/715757/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-13T19:37:00Z",
+          "officialDate": "2022-10-13",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "F",
+            "detailedState": "Final",
+            "statusCode": "F",
+            "startTimeTBD": false,
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 0,
+                "losses": 2,
+                "pct": ".000"
+              },
+              "score": 2,
+              "team": {
+                "id": 136,
+                "name": "Seattle Mariners",
+                "link": "/api/v1/teams/136"
+              },
+              "isWinner": false,
+              "splitSquad": false,
+              "seriesNumber": 1
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 2,
+                "losses": 0,
+                "pct": "1.000"
+              },
+              "score": 4,
+              "team": {
+                "id": 117,
+                "name": "Houston Astros",
+                "link": "/api/v1/teams/117"
+              },
+              "isWinner": true,
+              "splitSquad": false,
+              "seriesNumber": 1
+            }
+          },
+          "venue": {
+            "id": 2392,
+            "name": "Minute Maid Park",
+            "link": "/api/v1/venues/2392"
+          },
+          "content": {
+            "link": "/api/v1/game/715757/content"
+          },
+          "isTie": false,
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715757-2022-10-13",
+          "seasonDisplay": "2022",
+          "dayNight": "day",
+          "description": "ALDS Game 2",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 2,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        },
+        {
+          "gamePk": 715752,
+          "link": "/api/v1.1/game/715752/feed/live",
+          "gameType": "D",
+          "season": "2022",
+          "gameDate": "2022-10-13T23:37:00Z",
+          "officialDate": "2022-10-14",
+          "rescheduleDate": "2022-10-14T17:07:00Z",
+          "rescheduleGameDate": "2022-10-14",
+          "status": {
+            "abstractGameState": "Final",
+            "codedGameState": "D",
+            "detailedState": "Postponed",
+            "statusCode": "DI",
+            "startTimeTBD": false,
+            "reason": "Inclement Weather",
+            "abstractGameCode": "F"
+          },
+          "teams": {
+            "away": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "team": {
+                "id": 114,
+                "name": "Cleveland Guardians",
+                "link": "/api/v1/teams/114"
+              },
+              "splitSquad": false,
+              "seriesNumber": 2
+            },
+            "home": {
+              "leagueRecord": {
+                "wins": 1,
+                "losses": 1,
+                "pct": ".500"
+              },
+              "team": {
+                "id": 147,
+                "name": "New York Yankees",
+                "link": "/api/v1/teams/147"
+              },
+              "splitSquad": false,
+              "seriesNumber": 2
+            }
+          },
+          "venue": {
+            "id": 3313,
+            "name": "Yankee Stadium",
+            "link": "/api/v1/venues/3313"
+          },
+          "content": {
+            "link": "/api/v1/game/715752/content"
+          },
+          "gameNumber": 1,
+          "publicFacing": true,
+          "doubleHeader": "N",
+          "gamedayType": "P",
+          "tiebreaker": "N",
+          "calendarEventID": "14-715752-2022-10-13",
+          "seasonDisplay": "2022",
+          "dayNight": "night",
+          "description": "ALDS Game 2",
+          "scheduledInnings": 9,
+          "reverseHomeAwayStatus": false,
+          "inningBreakLength": 120,
+          "gamesInSeries": 5,
+          "seriesGameNumber": 2,
+          "seriesDescription": "Division Series",
+          "recordSource": "S",
+          "ifNecessary": "N",
+          "ifNecessaryDescription": "Normal Game"
+        }
+      ],
+      "events": []
+    }
+  ]
+}

--- a/tests/mock_tests/schedules/test_schedule_mock.py
+++ b/tests/mock_tests/schedules/test_schedule_mock.py
@@ -1,0 +1,91 @@
+﻿import unittest
+import requests_mock
+import json
+import os
+
+from mlbstatsapi import Mlb
+from mlbstatsapi.models.schedules import Schedule, ScheduleGames
+
+# Mocked JSON directory
+# TODO Find a better way to structure and handle this :) 
+path_to_current_file = os.path.realpath(__file__)
+current_directory = os.path.dirname(path_to_current_file)
+path_to_schedule_date = os.path.join(current_directory, "../mock_json/schedule/schedule_date.json")
+path_to_schedule_start_end_dates = os.path.join(current_directory, "../mock_json/schedule/schedule_start_end_date.json")
+path_to_not_found = os.path.join(current_directory, "../mock_json/response/not_found_404.json")
+path_to_error = os.path.join(current_directory, "../mock_json/response/error_500.json")
+
+SCHEDULES = open(path_to_schedule_date, "r", encoding="utf-8-sig").read()
+SCHEDULE = open(path_to_schedule_start_end_dates, "r", encoding="utf-8-sig").read()
+NOT_FOUND_404 = open(path_to_not_found, "r", encoding="utf-8-sig").read()
+ERROR_500 = open(path_to_error, "r", encoding="utf-8-sig").read()
+
+@requests_mock.Mocker()
+class TestScheduleMock(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.mlb = Mlb()
+        cls.al_team = 133
+
+        cls.mock_schedule = json.loads(SCHEDULE)
+        cls.mock_schedules = json.loads(SCHEDULE)
+
+        cls.error_500 = json.loads(ERROR_500)
+        cls.mock_not_found = json.loads(NOT_FOUND_404)
+
+                    
+    @classmethod
+    def tearDownClass(cls) -> None:
+        pass
+
+
+    def test_get_schedule(self, m ):
+        """get_schedule should return schedules for date, starDate, endDate"""
+        m.get('https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=04/07/2022&endDate=04/07/2022', json=self.mock_schedule,
+        status_code=200)
+        self.date = '04/07/2022'
+        self.sport_id = 1
+        schedule = self.mlb.get_schedule(date=self.date)
+
+        # get_schedule should return Schedule object
+        self.assertIsInstance(schedule, Schedule)
+        # get_schedule should return dates
+        self.assertTrue(schedule.dates)
+
+    def test_get_schedule_start_end_dates(self, m):
+        """get_schedule should return a schedule object with start_date, end_date"""
+        m.get('https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=10/10/2022&endDate=10/13/2022', json=self.mock_schedules,
+        status_code=200)
+        self.sport_id = 1
+        self.start_date = '10/10/2022'
+        self.end_date = '10/13/2022'
+        schedule = self.mlb.get_schedule(date=self.start_date, end_date=self.end_date, sport_id=self.sport_id)
+
+        # get_schedule should return Schedule object
+        self.assertIsInstance(schedule, Schedule)
+
+        # list should contain more than 1 object
+        self.assertTrue(len(schedule.dates) > 1)
+
+
+    def test_get_scheduled_games_by_date(self, m):
+        """get_schedule should return a ScheduledGames object with start_date, end_date"""
+        m.get('https://statsapi.mlb.com/api/v1/schedule?sportId=1&startDate=10/10/2022&endDate=10/13/2022', json=self.mock_schedules,
+        status_code=200)
+        self.sport_id = 1
+        self.start_date = '10/10/2022'
+        self.end_date = '10/13/2022'
+        
+        scheduled_games = self.mlb.get_scheduled_games_by_date(date=self.start_date, end_date=self.end_date, sport_id=1)
+
+        # scheduled games should not be none
+        self.assertIsNotNone(scheduled_games)
+
+        self.assertIsInstance(scheduled_games, list)
+
+        # scheduled games should not be empty list
+        self.assertNotEqual(scheduled_games, [])
+
+        scheduled_game = scheduled_games[0]
+
+        self.assertIsInstance(scheduled_game, ScheduleGames)


### PR DESCRIPTION
### Why
As a developer and User I want to a simple way to get games scheduled for a dates

### What

1. Added a get_scheduled_games_by_date function
2. Removed redundant functions for get_schedule and get_game_ids
3. Updated logic for get_game_ids to be more readable

### Tests
PyTest

### Risk and impact
- Minimal 

