### PR TITLE
Fixes issue #162

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package and its authors are not affiliated with MLB or any MLB team. This A
 
 ## Getting Started
 
-*Python-mlb-statsapi* is a Python library that provides developers with access to the MLB Stats API which allows developers to retrieve information related to MLB teams, players, stats, and more. *Python-mlb-statsapi* written in python 3.7+.
+*Python-mlb-statsapi* is a Python library that provides developers with access to the MLB Stats API which allows developers to retrieve information related to MLB teams, players, stats, and more. *Python-mlb-statsapi* written in python 3.10+.
 
 To get started with the library, refer to the information provided in this README. For a more detailed explanation, check out the documentation and the Wiki section. The Wiki contains information on return objects, endpoint structure, usage examples, and more. It is a valuable resource for getting started, working with the library, and finding the information you need.
 

--- a/docs/Wiki Pages/Home.md
+++ b/docs/Wiki Pages/Home.md
@@ -4,7 +4,7 @@ Welcome to the python-mlb-statsapi wiki!
 
 ### The unofficial python wrapper for the MLB Stats API
 
-*Python-mlb-statsapi* is an unofficial python wrapper for the MLB Stats API written in python 3.7+ and provides developers access to the MLB Stats API endpoint, created and maintained by [Kristian Nilssen](https://github.com/KCNilssen) and [Matthew Spah](https://github.com/Mattsface).
+*Python-mlb-statsapi* is an unofficial python wrapper for the MLB Stats API written in python 3.10+ and provides developers access to the MLB Stats API endpoint, created and maintained by [Kristian Nilssen](https://github.com/KCNilssen) and [Matthew Spah](https://github.com/Mattsface).
 
 Get started at [https://github.com/zero-sum-seattle/python-mlb-statsapi](https://github.com/zero-sum-seattle/python-mlb-statsapi)!
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.4.11"
+version = "0.4.12"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 description = "mlbstatsapi python wrapper"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = [
   "requests>=2", 
   "requests_mock>=1.10.0"


### PR DESCRIPTION
### Why

Python version reported in readme was incorrectly reading version 3.7+. This was brought to attention by @tomdmason. 

### What

Corrected versioning mistake from 3.7+ to 3.10+, due to python 3.10 being the earlier version supporting KW_ONLY. This fixes issue #162 Python Version compatibility

### Tests

No Testing

### Risk and impact

None