### PR TITLE
Draftpick Updates

### DIFF
--- a/mlbstatsapi/models/drafts/attributes.py
+++ b/mlbstatsapi/models/drafts/attributes.py
@@ -1,0 +1,44 @@
+﻿from dataclasses import dataclass, field
+
+
+@dataclass
+class Home:
+    """
+    A home is a where a draft player is from
+
+    Attributes
+    ----------
+    city : str
+        The city where the player is from.
+    state : str
+        The state where the player is from.
+    country : str
+        The country where the player is from.
+    """
+    city: str
+    state: str
+    country: str
+
+@dataclass
+class School:
+    """
+    Represents the school the draft player is from.
+
+    Attributes
+    ----------
+    name : str
+        The name of the school.
+    schoolclass : str
+        The class the student is in.
+    city : str
+        The city where the school is located.
+    country : str
+        The country where the school is located.
+    state : str
+        The state where the school is located.
+    """
+    name: str
+    schoolclass: str
+    city: str
+    country: str
+    state: str

--- a/mlbstatsapi/models/drafts/rounds.py
+++ b/mlbstatsapi/models/drafts/rounds.py
@@ -48,7 +48,6 @@ class DraftPick:
     year : str
         The year in which the draft took place.
     """
-    headshotlink: str
     team: Union[Team, dict]
     drafttype: Union[CodeDesc, dict]
     isdrafted: bool
@@ -59,6 +58,7 @@ class DraftPick:
     pickround:  str
     picknumber:  int
     roundpicknumber:  int
+    headshotlink: Optional[str] = None
     person: Optional[Union[Person, dict]] = None
     bisplayerid: Optional[int] = None
     rank: Optional[int] = None

--- a/mlbstatsapi/models/drafts/rounds.py
+++ b/mlbstatsapi/models/drafts/rounds.py
@@ -1,9 +1,75 @@
 ﻿from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional, Union
 
-from mlbstatsapi.models.people import DraftPick
-from mlbstatsapi import mlb_module
+from .attributes import School, Home
+from mlbstatsapi.models.teams import Team
+from mlbstatsapi.models.people import Person
+from mlbstatsapi.models.data import CodeDesc
 
+@dataclass(repr=False)
+class DraftPick:
+    """
+    Represents a pick made in the MLB draft.
+
+    Attributes
+    ----------
+    bisplayerid : int
+        The unique identifier of the player associated with this draft pick.
+    pickround : str
+        The round of the draft in which this pick was made.
+    picknumber : int
+        The number of the pick in the round.
+    roundpicknumber : int
+        The number of the pick overall in the draft.
+    rank : int
+        The rank of the player among all players eligible for the draft.
+    pickvalue : str
+        The value of the pick, if known.
+    signingbonus : str
+        The signing bonus associated with this pick, if known.
+    home : Home
+        Information about the player's home location.
+    scoutingreport : str
+    A   scouting report on the player's abilities.
+    school : School
+        Information about the player's school or college.
+    blurb : str
+        A   brief summary of the player's background and accomplishments.
+    headshotlink : str
+        A   link to a headshot image of the player.
+    team : Team or dict
+        The team that made this draft pick.
+    drafttype : CodeDesc
+        Information about the type of draft in which this pick was made.
+    isdrafted : bool
+        Whether or not the player associated with this pick has been drafted.
+    ispass : bool
+        Whether or not the team passed on making a pick in this round.
+    year : str
+        The year in which the draft took place.
+    """
+    headshotlink: str
+    team: Union[Team, dict]
+    drafttype: Union[CodeDesc, dict]
+    isdrafted: bool
+    ispass: bool
+    year: str
+    school: Union[School , dict] 
+    home: Union[Home, dict]
+    pickround:  str
+    picknumber:  int
+    roundpicknumber:  int
+    person: Optional[Union[Person, dict]] = None
+    bisplayerid: Optional[int] = None
+    rank: Optional[int] = None
+    pickvalue: Optional[str] = None
+    signingbonus:  Optional[str] = None
+    scoutingreport: Optional[str] = None
+    blurb: Optional[str] = None
+
+    def __repr__(self) -> str:
+        kws = [f'{key}={value}' for key, value in self.__dict__.items() if value is not None and value]
+        return "{}({})".format(type(self).__name__, ", ".join(kws))
 
 @dataclass(repr=False)
 class Round:
@@ -21,10 +87,7 @@ class Round:
     picks: List[DraftPick]
 
     def __post_init__(self):
-        picks = []
-        for pick in self.picks:
-            picks.append(DraftPick(**(mlb_module.merge_keys(pick, ['person']))))
-        self.picks = picks
+        self.picks = [DraftPick(**pick) for pick in self.picks]
 
     def __repr__(self) -> str:
         kws = [f'{key}={value}' for key, value in self.__dict__.items() if value is not None and value]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.4.14"
+version = "0.5.0"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/tests/external_tests/drafts/test_draft.py
+++ b/tests/external_tests/drafts/test_draft.py
@@ -41,7 +41,6 @@ class TestRound(unittest.TestCase):
         draftpick = draftpicks[0]
 
         # draft pick should have attrs set
-        self.assertTrue(draftpick.id)
         self.assertTrue(draftpick.pickround)
 
     def test_get_draft_by_year_id_404(self):

--- a/tests/mock_tests/drafts/test_draft_mock.py
+++ b/tests/mock_tests/drafts/test_draft_mock.py
@@ -58,5 +58,4 @@ class TestDraftMock(unittest.TestCase):
         draftpick = draftpicks[0]
 
         # draft pick should have attrs set
-        self.assertTrue(draftpick.id)
         self.assertTrue(draftpick.pickround)


### PR DESCRIPTION
### Why
As a developer and User I want to be able to call the draftpick endpoint for all available years. In order to do this further attributes needed to be set to optional.

### What

- Moved DraftPick out of people and into drafts to deal with person attribute being optional
- DraftPick is no longer a child of Person

### Tests
PyTest and Python CLI

### Risk and impact
- Minimal

