### PR TITLE
Updated stat tests with season params 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started with the library, refer to the information provided in this READM
 
 ## Installation
 ```python
-python3 -m pip install python-mlb-statsapi==0.5.5
+python3 -m pip install python-mlb-statsapi==0.5.7
 ```
 ## Usage
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.6"
+version = "0.5.7"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/tests/external_tests/mlbdataadapter/test_mlbadapter.py
+++ b/tests/external_tests/mlbdataadapter/test_mlbadapter.py
@@ -60,7 +60,7 @@ class TestMlbAdapter(unittest.TestCase):
         """mlbadapter should accept params and parse them to the url"""
 
         # stat type season, stat group hitting
-        self.params = {"stats": "season", "group": "hitting"}
+        self.params = {"stats": "season", "group": "hitting", "season": 2022}
 
         # use team stats end point for params
         result = self.mlb_adapter.get(endpoint="teams/133/stats", ep_params=self.params)

--- a/tests/external_tests/stats/test_catching.py
+++ b/tests/external_tests/stats/test_catching.py
@@ -11,20 +11,6 @@ class TestCatchingStats(unittest.TestCase):
         cls.al_team = 133
         cls.shoei_ohtani = 660271
         cls.catching_player = 663728
-        cls.stats_200_blank = ('projected', 'projectedRos', 'standard', 'advanced', 'firstYearStats', 'lastYearStats',
-        'vsOpponents', 'outsAboveAverage', 'tracking', 'availableStats', 'gameTypeStats', 'vsOpponents')
-        cls.catching = 'catching'
-        cls.stats_500 = ('careerStatSplits', 'metricLog', 'metricAverages', 'statSplits', 'statSplitsAdvanced')
-        # these stat groups require a team with recent playoff appearences 
-        cls.stats_playoffs = ('byMonthPlayoffs', 'byDayOfWeekPlayoffs', 'homeAndAwayPlayoffs', 'winLossPlayoffs')
-        # These stat groups require addition params passed like playerid or teamid
-        cls.stats_require_params = ('vsTeam', 'vsTeam5Y', 'vsTeamTotal', 'vsPlayer', 'vsPlayerTotal', 'vsPlayer5Y')
-        # These stat types should all return a stat split object for hitting and pitching stat groups
-        cls.catching = (
-                    "yearByYear", "yearByYearPlayoffs", "season", "career", "careerRegularSeason",
-                    "careerPlayoffs", "gameLog", "lastXGames", "byDateRange", "byDateRangeAdvanced",
-                    "byMonth", "byDayOfWeek", "homeAndAway", "winLoss", "atGameStart"
-                    )
                     
     @classmethod
     def tearDownClass(cls) -> None:
@@ -34,8 +20,9 @@ class TestCatchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career']
         self.group = ['catching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.catching_player, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.catching_player, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -64,8 +51,9 @@ class TestCatchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career']
         self.group = ['catching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})

--- a/tests/external_tests/stats/test_fielding.py
+++ b/tests/external_tests/stats/test_fielding.py
@@ -11,20 +11,6 @@ class TestPitchingStats(unittest.TestCase):
         cls.al_team = 133
         cls.shoei_ohtani = 660271
         cls.utility_player = 647351
-        cls.stats_200_blank = ('projected', 'projectedRos', 'standard', 'advanced', 'firstYearStats', 'lastYearStats',
-        'vsOpponents', 'outsAboveAverage', 'tracking', 'availableStats', 'gameTypeStats', 'vsOpponents')
-        cls.pitching = 'pitching'
-        cls.stats_500 = ('careerStatSplits', 'metricLog', 'metricAverages', 'statSplits', 'statSplitsAdvanced')
-        # these stat groups require a team with recent playoff appearences 
-        cls.stats_playoffs = ('byMonthPlayoffs', 'byDayOfWeekPlayoffs', 'homeAndAwayPlayoffs', 'winLossPlayoffs')
-        # These stat groups require addition params passed like playerid or teamid
-        cls.stats_require_params = ('vsTeam', 'vsTeam5Y', 'vsTeamTotal', 'vsPlayer', 'vsPlayerTotal', 'vsPlayer5Y')
-        # These stat types should all return a stat split object for hitting and pitching stat groups
-        cls.fielding = (
-                    "yearByYear", "yearByYearPlayoffs", "season", "career", "careerRegularSeason",
-                    "careerPlayoffs", "gameLog", "lastXGames", "byDateRange", "byDateRangeAdvanced",
-                    "byMonth", "byDayOfWeek", "homeAndAway", "winLoss", "opponentsFaced", "atGameStart",
-                    )
                     
     @classmethod
     def tearDownClass(cls) -> None:
@@ -34,8 +20,10 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career']
         self.group = ['fielding']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.utility_player, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.utility_player, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -69,8 +57,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career', 'seasonAdvanced', 'careerAdvanced']
         self.group = ['fielding']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})

--- a/tests/external_tests/stats/test_hitting.py
+++ b/tests/external_tests/stats/test_hitting.py
@@ -14,15 +14,6 @@ class TestHittingStats(unittest.TestCase):
         cls.ty_france = 664034
         cls.utility_player = 647351
         cls.soto = 665742
-        cls.stats_200_blank = ('projected', 'projectedRos', 'standard', 'advanced', 'firstYearStats', 'lastYearStats',
-        'vsOpponents', 'outsAboveAverage', 'tracking', 'availableStats', 'gameTypeStats', 'vsOpponents')
-        cls.hitting = 'hitting'
-        cls.stats_500 = ('careerStatSplits', 'metricLog', 'metricAverages', 'statSplits', 'statSplitsAdvanced')
-        # these stat groups require a team with recent playoff appearences 
-        cls.stats_playoffs = ('byMonthPlayoffs', 'byDayOfWeekPlayoffs', 'homeAndAwayPlayoffs', 'winLossPlayoffs')
-        # These stat groups require addition params passed like playerid or teamid
-        cls.stats_require_params = ('vsTeam', 'vsTeam5Y', 'vsTeamTotal', 'vsPlayer', 'vsPlayerTotal', 'vsPlayer5Y')
-        # These stat types should all return a stat split object for hitting and pitching stat groups
 
                     
     @classmethod

--- a/tests/external_tests/stats/test_hitting.py
+++ b/tests/external_tests/stats/test_hitting.py
@@ -23,14 +23,7 @@ class TestHittingStats(unittest.TestCase):
         # These stat groups require addition params passed like playerid or teamid
         cls.stats_require_params = ('vsTeam', 'vsTeam5Y', 'vsTeamTotal', 'vsPlayer', 'vsPlayerTotal', 'vsPlayer5Y')
         # These stat types should all return a stat split object for hitting and pitching stat groups
-        cls.hitting = (
-                    "yearByYear", "yearByYearAdvanced", "yearByYearPlayoffs", "season",
-                    "career", "careerRegularSeason", "careerAdvanced", "seasonAdvanced", "careerPlayoffs",
-                    "gameLog", "playLog", "pitchLog", "pitchArsenal", "expectedStatistics", "sabermetrics",
-                    "sprayChart", "lastXGames", "byDateRange", "byDateRangeAdvanced", "byMonth", "byDayOfWeek",
-                    "homeAndAway", "winLoss", "rankings", "rankingsByYear", "statsSingleSeason", "statsSingleSeasonAdvanced",
-                    "hotColdZones", "opponentsFaced", "atGameStart"
-                    )
+
                     
     @classmethod
     def tearDownClass(cls) -> None:
@@ -40,8 +33,9 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career','seasonAdvanced', 'careerAdvanced']
         self.group = ['hitting']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -84,9 +78,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career', 'seasonAdvanced', 'careerAdvanced']
         self.group = ['hitting']
+        self.params = {'season': 2022}
         # let's get some stats
         # let's get some stats
-        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -149,8 +144,9 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['expectedStatistics']
         self.group = ['hitting']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -165,8 +161,9 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['byDateRange', 'byDateRangeAdvanced']
         self.group = ['hitting']
+        self.params = {'season': 2022, 'startDate': '2022-05-07'}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -182,8 +179,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['byMonth']
         self.group = ['hitting']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -198,8 +197,9 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['byDayOfWeek']
         self.group = ['hitting']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -214,7 +214,7 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['vsPlayer']
         self.group = ['hitting']
-        self.params = {'opposingPlayerId': 660271}
+        self.params = {'opposingPlayerId': 660271, 'season': 2022}
         # let's get some stats
         stats = self.mlb.get_player_stats(self.ty_france, stats=self.stats, groups=self.group, **self.params)
 
@@ -231,7 +231,7 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['vsTeam']
         self.group = ['hitting']
-        self.params = {'opposingTeamId': 133}
+        self.params = {'opposingTeamId': 133, 'season': 2022}
 
         # let's get some stats
         stats = self.mlb.get_player_stats(self.ty_france, stats=self.stats, groups=self.group, **self.params)
@@ -249,7 +249,7 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['vsTeam']
         self.group = ['hitting']
-        self.params = {'opposingTeamId': 136}
+        self.params = {'opposingTeamId': 136, 'season': 2022}
 
         # let's get some stats
         stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group, **self.params)
@@ -267,8 +267,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['pitchLog']
         self.group = ['hitting']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -288,8 +290,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['playLog']
         self.group = ['hitting']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -310,8 +314,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['pitchArsenal']
         self.group = ['hitting']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -330,8 +336,10 @@ class TestHittingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['hotColdZones']
         self.group = ['hitting']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})

--- a/tests/external_tests/stats/test_pitching.py
+++ b/tests/external_tests/stats/test_pitching.py
@@ -12,23 +12,6 @@ class TestPitchingStats(unittest.TestCase):
         cls.shoei_ohtani = 660271
         cls.utility_player = 647351
         cls.ty_france = 664034
-        cls.stats_200_blank = ('projected', 'projectedRos', 'standard', 'advanced', 'firstYearStats', 'lastYearStats',
-        'vsOpponents', 'outsAboveAverage', 'tracking', 'availableStats', 'gameTypeStats', 'vsOpponents')
-        cls.pitching = 'pitching'
-        cls.stats_500 = ('careerStatSplits', 'metricLog', 'metricAverages', 'statSplits', 'statSplitsAdvanced')
-        # these stat groups require a team with recent playoff appearences 
-        cls.stats_playoffs = ('byMonthPlayoffs', 'bydayofweekPlayoffs', 'homeAndAwayPlayoffs', 'winLossPlayoffs')
-        # These stat groups require addition params passed like playerid or teamid
-        cls.stats_require_params = ('vsTeam', 'vsTeam5Y', 'vsTeamTotal', 'vsPlayer', 'vsPlayerTotal', 'vsPlayer5Y')
-        # These stat types should all return a stat split object for hitting and pitching stat groups
-        cls.pitching = (
-                    "yearByYear", "yearByYearAdvanced", "yearByYearPlayoffs", "season",
-                    "career", "careerRegularSeason", "careerAdvanced", "seasonAdvanced", "careerPlayoffs",
-                    "gameLog", "playLog", "pitchLog", "pitchArsenal", "expectedStatistics", "sabermetrics",
-                    "sprayChart", "lastXGames", "byDateRange", "byDateRangeAdvanced", "byMonth", "byDayOfWeek",
-                    "homeAndAway", "winLoss", "rankings", "rankingsByYear", "statsSingleSeason", "statsSingleSeasonAdvanced",
-                    "hotColdZones", "opponentsFaced", "atGameStart"
-                    )
                     
     @classmethod
     def tearDownClass(cls) -> None:
@@ -38,8 +21,10 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career', 'seasonAdvanced', 'careerAdvanced']
         self.group = ['pitching']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -80,8 +65,10 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['season', 'career','seasonAdvanced', 'careerAdvanced']
         self.group = ['pitching']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_team_stats(self.al_team, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -122,8 +109,10 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['expectedStatistics']
         self.group = ['pitching']
+        self.params = {'season': 2022}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -139,8 +128,10 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['byDateRange', 'byDateRangeAdvanced']
         self.group = ['pitching']
+        self.params = {'season': 2022, 'startDate': '2022-05-07'}
+
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -156,8 +147,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['byMonth']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -172,8 +164,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return pitching stats"""
         self.stats = ['byDayOfWeek']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -205,8 +198,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['pitchLog']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -221,8 +215,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['playLog']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -237,8 +232,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['pitchArsenal']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})
@@ -253,8 +249,9 @@ class TestPitchingStats(unittest.TestCase):
         """mlb get stats should return hitting stats"""
         self.stats = ['hotColdZones']
         self.group = ['pitching']
+        self.params = {'season': 2022}
         # let's get some stats
-        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group)
+        stats = self.mlb.get_player_stats(self.shoei_ohtani, stats=self.stats, groups=self.group, **self.params)
 
         # check for empty dict
         self.assertNotEqual(stats, {})


### PR DESCRIPTION
### Why
The new MLB season is starting, and the current external tests do not specify a season. The stats endpoint defaults to the latest season which has no data. #179

### What
Updated all stat tests with a season param 

### Tests
PyTest

### Risk and impact
- Minimal

