### PR TITLE
Apiupdatefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started with the library, refer to the information provided in this READM
 
 ## Installation
 ```python
-python3 -m pip install python-mlb-statsapi==0.5.10
+python3 -m pip install python-mlb-statsapi==0.5.12
 ```
 ## Usage
 ```python

--- a/mlbstatsapi/models/game/livedata/boxscore/attributes.py
+++ b/mlbstatsapi/models/game/livedata/boxscore/attributes.py
@@ -90,11 +90,11 @@ class PlayersDictPerson:
         All of the person's positions if avaliable.
     """
     person: Union[Person, dict]
-    position: Union[Position, dict]
     status: Union[CodeDesc, dict]
     stats: dict
     seasonstats: dict
     gamestatus: Union[GameStatus, dict]
+    position: Optional[Union[Position, dict]] = None
     battingorder: Optional[int] = None
     jerseynumber: Optional[str] = None
     parentteamid: Optional[int] = None
@@ -102,7 +102,7 @@ class PlayersDictPerson:
 
     def __post_init__(self):
         self.person = Person(**self.person)
-        self.position = Position(**self.position)
+        self.position = Position(**self.position) if self.position else self.position
         self.status = CodeDesc(**self.status)
         self.gamestatus = GameStatus(**self.gamestatus)
         self.allpositions = [Position(**allposition) for allposition in self.allpositions] if self.allpositions else self.allpositions

--- a/mlbstatsapi/models/people/people.py
+++ b/mlbstatsapi/models/people/people.py
@@ -179,7 +179,7 @@ class Player(Person):
     status : 
         Status of the player
     parentteamid : int
-        parent team id
+        parent team id        
     """
     jerseynumber: str
     parentteamid: int
@@ -187,7 +187,7 @@ class Player(Person):
     status: Union[Status, dict]
 
     def __post_init__(self, position: dict):
-        self.primaryposition = Position(**position)
+        self.primaryposition = Position(**position) if position else None
 
 
 @dataclass(kw_only=True, repr=False)

--- a/mlbstatsapi/models/standings/attributes.py
+++ b/mlbstatsapi/models/standings/attributes.py
@@ -119,6 +119,10 @@ class Teamrecords(TeamRecord):
     haswildcard: bool
     clinched: bool
     eliminationnumber: str
+    eliminationnumbersport: str
+    eliminationnumberleague: str
+    eliminationnumberdivision: str
+    eliminationnumberconference: str
     wildcardeliminationnumber: str    
     # wins: int
     # losses: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.11"
+version = "0.5.12"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/tests/mock_tests/mock_json/standings/standings.json
+++ b/tests/mock_tests/mock_json/standings/standings.json
@@ -1,5 +1,5 @@
 {
-    "copyright": "Copyright 2022 MLB Advanced Media, L.P.  Use of any content on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt",
+    "copyright": "Copyright 2023 MLB Advanced Media, L.P.  Use of any content on this page acknowledges agreement to the terms posted here http://gdx.mlb.com/components/copyright.txt",
     "records": [
         {
             "standingsType": "regularSeason",
@@ -15,39 +15,39 @@
                 "id": 1,
                 "link": "/api/v1/sports/1"
             },
-            "lastUpdated": "2022-01-21T18:46:25.113Z",
+            "lastUpdated": "2023-06-03T15:24:33.307Z",
             "teamRecords": [
                 {
                     "team": {
-                        "id": 111,
-                        "name": "Boston Red Sox",
-                        "link": "/api/v1/teams/111"
+                        "id": 147,
+                        "name": "New York Yankees",
+                        "link": "/api/v1/teams/147"
                     },
-                    "season": "2018",
+                    "season": "2022",
                     "streak": {
-                        "streakType": "wins",
-                        "streakNumber": 1,
-                        "streakCode": "W1"
+                        "streakType": "losses",
+                        "streakNumber": 2,
+                        "streakCode": "L2"
                     },
-                    "clinchIndicator": "z",
+                    "clinchIndicator": "y",
                     "divisionRank": "1",
-                    "leagueRank": "1",
-                    "sportRank": "1",
+                    "leagueRank": "2",
+                    "sportRank": "2",
                     "gamesPlayed": 162,
                     "gamesBack": "-",
                     "wildCardGamesBack": "-",
-                    "leagueGamesBack": "-",
+                    "leagueGamesBack": "7.0",
                     "springLeagueGamesBack": "-",
-                    "sportGamesBack": "-",
+                    "sportGamesBack": "7.0",
                     "divisionGamesBack": "-",
                     "conferenceGamesBack": "-",
                     "leagueRecord": {
-                        "wins": 108,
-                        "losses": 54,
+                        "wins": 99,
+                        "losses": 63,
                         "ties": 0,
-                        "pct": ".667"
+                        "pct": ".611"
                     },
-                    "lastUpdated": "2022-01-21T18:46:25Z",
+                    "lastUpdated": "2023-06-03T15:24:33Z",
                     "records": {
                         "splitRecords": [
                             {
@@ -57,46 +57,46 @@
                                 "pct": ".704"
                             },
                             {
-                                "wins": 51,
-                                "losses": 30,
+                                "wins": 42,
+                                "losses": 39,
                                 "type": "away",
-                                "pct": ".630"
+                                "pct": ".519"
                             },
                             {
-                                "wins": 21,
-                                "losses": 16,
+                                "wins": 26,
+                                "losses": 15,
                                 "type": "left",
-                                "pct": ".568"
+                                "pct": ".634"
                             },
                             {
-                                "wins": 13,
-                                "losses": 5,
+                                "wins": 16,
+                                "losses": 2,
                                 "type": "leftHome",
-                                "pct": ".722"
+                                "pct": ".889"
                             },
                             {
-                                "wins": 8,
-                                "losses": 11,
+                                "wins": 10,
+                                "losses": 13,
                                 "type": "leftAway",
-                                "pct": ".421"
+                                "pct": ".435"
                             },
                             {
-                                "wins": 44,
-                                "losses": 19,
+                                "wins": 41,
+                                "losses": 22,
                                 "type": "rightHome",
-                                "pct": ".698"
+                                "pct": ".651"
                             },
                             {
-                                "wins": 43,
-                                "losses": 19,
+                                "wins": 32,
+                                "losses": 26,
                                 "type": "rightAway",
-                                "pct": ".694"
+                                "pct": ".552"
                             },
                             {
-                                "wins": 87,
-                                "losses": 38,
+                                "wins": 73,
+                                "losses": 48,
                                 "type": "right",
-                                "pct": ".696"
+                                "pct": ".603"
                             },
                             {
                                 "wins": 5,
@@ -105,53 +105,53 @@
                                 "pct": ".500"
                             },
                             {
-                                "wins": 8,
-                                "losses": 5,
-                                "type": "extraInning",
-                                "pct": ".615"
-                            },
-                            {
-                                "wins": 25,
-                                "losses": 14,
-                                "type": "oneRun",
-                                "pct": ".641"
-                            },
-                            {
-                                "wins": 41,
-                                "losses": 33,
-                                "type": "winners",
-                                "pct": ".554"
-                            },
-                            {
-                                "wins": 37,
-                                "losses": 11,
-                                "type": "day",
-                                "pct": ".771"
-                            },
-                            {
-                                "wins": 71,
-                                "losses": 43,
-                                "type": "night",
-                                "pct": ".623"
-                            },
-                            {
-                                "wins": 97,
-                                "losses": 46,
-                                "type": "grass",
-                                "pct": ".678"
-                            },
-                            {
-                                "wins": 11,
+                                "wins": 10,
                                 "losses": 8,
+                                "type": "extraInning",
+                                "pct": ".556"
+                            },
+                            {
+                                "wins": 31,
+                                "losses": 27,
+                                "type": "oneRun",
+                                "pct": ".534"
+                            },
+                            {
+                                "wins": 50,
+                                "losses": 43,
+                                "type": "winners",
+                                "pct": ".538"
+                            },
+                            {
+                                "wins": 33,
+                                "losses": 19,
+                                "type": "day",
+                                "pct": ".635"
+                            },
+                            {
+                                "wins": 66,
+                                "losses": 44,
+                                "type": "night",
+                                "pct": ".600"
+                            },
+                            {
+                                "wins": 86,
+                                "losses": 53,
+                                "type": "grass",
+                                "pct": ".619"
+                            },
+                            {
+                                "wins": 13,
+                                "losses": 10,
                                 "type": "turf",
-                                "pct": ".579"
+                                "pct": ".565"
                             }
                         ],
                         "divisionRecords": [
                             {
-                                "wins": 21,
-                                "losses": 12,
-                                "pct": ".636",
+                                "wins": 17,
+                                "losses": 16,
+                                "pct": ".515",
                                 "division": {
                                     "id": 200,
                                     "name": "American League West",
@@ -159,9 +159,9 @@
                                 }
                             },
                             {
-                                "wins": 52,
-                                "losses": 24,
-                                "pct": ".684",
+                                "wins": 47,
+                                "losses": 29,
+                                "pct": ".618",
                                 "division": {
                                     "id": 201,
                                     "name": "American League East",
@@ -169,9 +169,9 @@
                                 }
                             },
                             {
-                                "wins": 19,
-                                "losses": 14,
-                                "pct": ".576",
+                                "wins": 25,
+                                "losses": 8,
+                                "pct": ".758",
                                 "division": {
                                     "id": 202,
                                     "name": "American League Central",
@@ -187,238 +187,10 @@
                                 "pct": ".704"
                             },
                             {
-                                "wins": 51,
-                                "losses": 30,
+                                "wins": 42,
+                                "losses": 39,
                                 "type": "away",
-                                "pct": ".630"
-                            }
-                        ],
-                        "leagueRecords": [
-                            {
-                                "wins": 92,
-                                "losses": 50,
-                                "pct": ".648",
-                                "league": {
-                                    "id": 103,
-                                    "name": "American League",
-                                    "link": "/api/v1/league/103"
-                                }
-                            },
-                            {
-                                "wins": 16,
-                                "losses": 4,
-                                "pct": ".800",
-                                "league": {
-                                    "id": 104,
-                                    "name": "National League",
-                                    "link": "/api/v1/league/104"
-                                }
-                            }
-                        ],
-                        "expectedRecords": [
-                            {
-                                "wins": 103,
-                                "losses": 59,
-                                "type": "xWinLoss",
-                                "pct": ".636"
-                            },
-                            {
-                                "wins": 103,
-                                "losses": 59,
-                                "type": "xWinLossSeason",
-                                "pct": ".636"
-                            }
-                        ]
-                    },
-                    "runsAllowed": 647,
-                    "runsScored": 876,
-                    "divisionChamp": true,
-                    "divisionLeader": true,
-                    "hasWildcard": true,
-                    "clinched": true,
-                    "eliminationNumber": "-",
-                    "wildCardEliminationNumber": "-",
-                    "magicNumber": "-",
-                    "wins": 108,
-                    "losses": 54,
-                    "runDifferential": 229,
-                    "winningPercentage": ".667"
-                },
-                {
-                    "team": {
-                        "id": 147,
-                        "name": "New York Yankees",
-                        "link": "/api/v1/teams/147"
-                    },
-                    "season": "2018",
-                    "streak": {
-                        "streakType": "losses",
-                        "streakNumber": 1,
-                        "streakCode": "L1"
-                    },
-                    "clinchIndicator": "w",
-                    "divisionRank": "2",
-                    "leagueRank": "3",
-                    "wildCardRank": "1",
-                    "sportRank": "3",
-                    "gamesPlayed": 162,
-                    "gamesBack": "8.0",
-                    "wildCardGamesBack": "+3.0",
-                    "leagueGamesBack": "8.0",
-                    "springLeagueGamesBack": "-",
-                    "sportGamesBack": "8.0",
-                    "divisionGamesBack": "8.0",
-                    "conferenceGamesBack": "-",
-                    "leagueRecord": {
-                        "wins": 100,
-                        "losses": 62,
-                        "ties": 0,
-                        "pct": ".617"
-                    },
-                    "lastUpdated": "2021-11-23T01:20:19Z",
-                    "records": {
-                        "splitRecords": [
-                            {
-                                "wins": 53,
-                                "losses": 28,
-                                "type": "home",
-                                "pct": ".654"
-                            },
-                            {
-                                "wins": 47,
-                                "losses": 34,
-                                "type": "away",
-                                "pct": ".580"
-                            },
-                            {
-                                "wins": 30,
-                                "losses": 15,
-                                "type": "left",
-                                "pct": ".667"
-                            },
-                            {
-                                "wins": 18,
-                                "losses": 10,
-                                "type": "leftHome",
-                                "pct": ".643"
-                            },
-                            {
-                                "wins": 12,
-                                "losses": 5,
-                                "type": "leftAway",
-                                "pct": ".706"
-                            },
-                            {
-                                "wins": 35,
-                                "losses": 18,
-                                "type": "rightHome",
-                                "pct": ".660"
-                            },
-                            {
-                                "wins": 35,
-                                "losses": 29,
-                                "type": "rightAway",
-                                "pct": ".547"
-                            },
-                            {
-                                "wins": 70,
-                                "losses": 47,
-                                "type": "right",
-                                "pct": ".598"
-                            },
-                            {
-                                "wins": 7,
-                                "losses": 3,
-                                "type": "lastTen",
-                                "pct": ".700"
-                            },
-                            {
-                                "wins": 9,
-                                "losses": 5,
-                                "type": "extraInning",
-                                "pct": ".643"
-                            },
-                            {
-                                "wins": 23,
-                                "losses": 17,
-                                "type": "oneRun",
-                                "pct": ".575"
-                            },
-                            {
-                                "wins": 41,
-                                "losses": 30,
-                                "type": "winners",
-                                "pct": ".577"
-                            },
-                            {
-                                "wins": 36,
-                                "losses": 21,
-                                "type": "day",
-                                "pct": ".632"
-                            },
-                            {
-                                "wins": 64,
-                                "losses": 41,
-                                "type": "night",
-                                "pct": ".610"
-                            },
-                            {
-                                "wins": 90,
-                                "losses": 53,
-                                "type": "grass",
-                                "pct": ".629"
-                            },
-                            {
-                                "wins": 10,
-                                "losses": 9,
-                                "type": "turf",
-                                "pct": ".526"
-                            }
-                        ],
-                        "divisionRecords": [
-                            {
-                                "wins": 22,
-                                "losses": 10,
-                                "pct": ".688",
-                                "division": {
-                                    "id": 200,
-                                    "name": "American League West",
-                                    "link": "/api/v1/divisions/200"
-                                }
-                            },
-                            {
-                                "wins": 44,
-                                "losses": 32,
-                                "pct": ".579",
-                                "division": {
-                                    "id": 201,
-                                    "name": "American League East",
-                                    "link": "/api/v1/divisions/201"
-                                }
-                            },
-                            {
-                                "wins": 23,
-                                "losses": 11,
-                                "pct": ".676",
-                                "division": {
-                                    "id": 202,
-                                    "name": "American League Central",
-                                    "link": "/api/v1/divisions/202"
-                                }
-                            }
-                        ],
-                        "overallRecords": [
-                            {
-                                "wins": 53,
-                                "losses": 28,
-                                "type": "home",
-                                "pct": ".654"
-                            },
-                            {
-                                "wins": 47,
-                                "losses": 34,
-                                "type": "away",
-                                "pct": ".580"
+                                "pct": ".519"
                             }
                         ],
                         "leagueRecords": [
@@ -433,254 +205,9 @@
                                 }
                             },
                             {
-                                "wins": 11,
-                                "losses": 9,
-                                "pct": ".550",
-                                "league": {
-                                    "id": 104,
-                                    "name": "National League",
-                                    "link": "/api/v1/league/104"
-                                }
-                            }
-                        ],
-                        "expectedRecords": [
-                            {
-                                "wins": 99,
-                                "losses": 63,
-                                "type": "xWinLoss",
-                                "pct": ".611"
-                            },
-                            {
-                                "wins": 99,
-                                "losses": 63,
-                                "type": "xWinLossSeason",
-                                "pct": ".611"
-                            }
-                        ]
-                    },
-                    "runsAllowed": 669,
-                    "runsScored": 851,
-                    "divisionChamp": false,
-                    "divisionLeader": false,
-                    "wildCardLeader": true,
-                    "hasWildcard": true,
-                    "clinched": true,
-                    "eliminationNumber": "E",
-                    "wildCardEliminationNumber": "-",
-                    "wins": 100,
-                    "losses": 62,
-                    "runDifferential": 182,
-                    "winningPercentage": ".617"
-                }
-            ]
-        },
-        {
-            "standingsType": "regularSeason",
-            "league": {
-                "id": 103,
-                "link": "/api/v1/league/103"
-            },
-            "division": {
-                "id": 202,
-                "link": "/api/v1/divisions/202"
-            },
-            "sport": {
-                "id": 1,
-                "link": "/api/v1/sports/1"
-            },
-            "lastUpdated": "2022-01-19T19:14:00.522Z",
-            "teamRecords": [
-                {
-                    "team": {
-                        "id": 114,
-                        "name": "Cleveland Indians",
-                        "link": "/api/v1/teams/114"
-                    },
-                    "season": "2018",
-                    "streak": {
-                        "streakType": "wins",
-                        "streakNumber": 1,
-                        "streakCode": "W1"
-                    },
-                    "clinchIndicator": "y",
-                    "divisionRank": "1",
-                    "leagueRank": "5",
-                    "sportRank": "5",
-                    "gamesPlayed": 162,
-                    "gamesBack": "-",
-                    "wildCardGamesBack": "-",
-                    "leagueGamesBack": "17.0",
-                    "springLeagueGamesBack": "-",
-                    "sportGamesBack": "17.0",
-                    "divisionGamesBack": "-",
-                    "conferenceGamesBack": "-",
-                    "leagueRecord": {
-                        "wins": 91,
-                        "losses": 71,
-                        "ties": 0,
-                        "pct": ".562"
-                    },
-                    "lastUpdated": "2021-11-23T01:17:55Z",
-                    "records": {
-                        "splitRecords": [
-                            {
-                                "wins": 49,
-                                "losses": 32,
-                                "type": "home",
-                                "pct": ".605"
-                            },
-                            {
-                                "wins": 42,
-                                "losses": 39,
-                                "type": "away",
-                                "pct": ".519"
-                            },
-                            {
-                                "wins": 22,
-                                "losses": 21,
-                                "type": "left",
-                                "pct": ".512"
-                            },
-                            {
-                                "wins": 12,
-                                "losses": 11,
-                                "type": "leftHome",
-                                "pct": ".522"
-                            },
-                            {
                                 "wins": 10,
                                 "losses": 10,
-                                "type": "leftAway",
-                                "pct": ".500"
-                            },
-                            {
-                                "wins": 37,
-                                "losses": 21,
-                                "type": "rightHome",
-                                "pct": ".638"
-                            },
-                            {
-                                "wins": 32,
-                                "losses": 29,
-                                "type": "rightAway",
-                                "pct": ".525"
-                            },
-                            {
-                                "wins": 69,
-                                "losses": 50,
-                                "type": "right",
-                                "pct": ".580"
-                            },
-                            {
-                                "wins": 6,
-                                "losses": 4,
-                                "type": "lastTen",
-                                "pct": ".600"
-                            },
-                            {
-                                "wins": 4,
-                                "losses": 9,
-                                "type": "extraInning",
-                                "pct": ".308"
-                            },
-                            {
-                                "wins": 22,
-                                "losses": 24,
-                                "type": "oneRun",
-                                "pct": ".478"
-                            },
-                            {
-                                "wins": 23,
-                                "losses": 31,
-                                "type": "winners",
-                                "pct": ".426"
-                            },
-                            {
-                                "wins": 36,
-                                "losses": 23,
-                                "type": "day",
-                                "pct": ".610"
-                            },
-                            {
-                                "wins": 55,
-                                "losses": 48,
-                                "type": "night",
-                                "pct": ".534"
-                            },
-                            {
-                                "wins": 87,
-                                "losses": 66,
-                                "type": "grass",
-                                "pct": ".569"
-                            },
-                            {
-                                "wins": 4,
-                                "losses": 5,
-                                "type": "turf",
-                                "pct": ".444"
-                            }
-                        ],
-                        "divisionRecords": [
-                            {
-                                "wins": 14,
-                                "losses": 18,
-                                "pct": ".438",
-                                "division": {
-                                    "id": 200,
-                                    "name": "American League West",
-                                    "link": "/api/v1/divisions/200"
-                                }
-                            },
-                            {
-                                "wins": 16,
-                                "losses": 18,
-                                "pct": ".471",
-                                "division": {
-                                    "id": 201,
-                                    "name": "American League East",
-                                    "link": "/api/v1/divisions/201"
-                                }
-                            },
-                            {
-                                "wins": 49,
-                                "losses": 27,
-                                "pct": ".645",
-                                "division": {
-                                    "id": 202,
-                                    "name": "American League Central",
-                                    "link": "/api/v1/divisions/202"
-                                }
-                            }
-                        ],
-                        "overallRecords": [
-                            {
-                                "wins": 49,
-                                "losses": 32,
-                                "type": "home",
-                                "pct": ".605"
-                            },
-                            {
-                                "wins": 42,
-                                "losses": 39,
-                                "type": "away",
-                                "pct": ".519"
-                            }
-                        ],
-                        "leagueRecords": [
-                            {
-                                "wins": 79,
-                                "losses": 63,
-                                "pct": ".556",
-                                "league": {
-                                    "id": 103,
-                                    "name": "American League",
-                                    "link": "/api/v1/league/103"
-                                }
-                            },
-                            {
-                                "wins": 12,
-                                "losses": 8,
-                                "pct": ".600",
+                                "pct": ".500",
                                 "league": {
                                     "id": 104,
                                     "name": "National League",
@@ -690,113 +217,118 @@
                         ],
                         "expectedRecords": [
                             {
-                                "wins": 98,
-                                "losses": 64,
+                                "wins": 106,
+                                "losses": 56,
                                 "type": "xWinLoss",
-                                "pct": ".605"
+                                "pct": ".654"
                             },
                             {
-                                "wins": 98,
-                                "losses": 64,
+                                "wins": 106,
+                                "losses": 56,
                                 "type": "xWinLossSeason",
-                                "pct": ".605"
+                                "pct": ".654"
                             }
                         ]
                     },
-                    "runsAllowed": 648,
-                    "runsScored": 818,
+                    "runsAllowed": 567,
+                    "runsScored": 807,
                     "divisionChamp": true,
                     "divisionLeader": true,
                     "hasWildcard": true,
                     "clinched": true,
                     "eliminationNumber": "-",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "E",
+                    "eliminationNumberDivision": "-",
+                    "eliminationNumberConference": "97",
                     "wildCardEliminationNumber": "-",
                     "magicNumber": "-",
-                    "wins": 91,
-                    "losses": 71,
-                    "runDifferential": 170,
-                    "winningPercentage": ".562"
+                    "wins": 99,
+                    "losses": 63,
+                    "runDifferential": 240,
+                    "winningPercentage": ".611"
                 },
                 {
                     "team": {
-                        "id": 142,
-                        "name": "Minnesota Twins",
-                        "link": "/api/v1/teams/142"
+                        "id": 141,
+                        "name": "Toronto Blue Jays",
+                        "link": "/api/v1/teams/141"
                     },
-                    "season": "2018",
+                    "season": "2022",
                     "streak": {
                         "streakType": "wins",
-                        "streakNumber": 6,
-                        "streakCode": "W6"
+                        "streakNumber": 1,
+                        "streakCode": "W1"
                     },
+                    "clinchIndicator": "w",
                     "divisionRank": "2",
-                    "leagueRank": "9",
-                    "wildCardRank": "6",
-                    "sportRank": "9",
+                    "leagueRank": "4",
+                    "wildCardRank": "1",
+                    "sportRank": "4",
                     "gamesPlayed": 162,
-                    "gamesBack": "13.0",
-                    "wildCardGamesBack": "19.0",
-                    "leagueGamesBack": "30.0",
+                    "gamesBack": "7.0",
+                    "wildCardGamesBack": "+6.0",
+                    "leagueGamesBack": "14.0",
                     "springLeagueGamesBack": "-",
-                    "sportGamesBack": "30.0",
-                    "divisionGamesBack": "13.0",
+                    "sportGamesBack": "14.0",
+                    "divisionGamesBack": "7.0",
                     "conferenceGamesBack": "-",
                     "leagueRecord": {
-                        "wins": 78,
-                        "losses": 84,
+                        "wins": 92,
+                        "losses": 70,
                         "ties": 0,
-                        "pct": ".481"
+                        "pct": ".568"
                     },
-                    "lastUpdated": "2021-11-13T21:10:05Z",
+                    "lastUpdated": "2023-05-31T21:40:50Z",
                     "records": {
                         "splitRecords": [
                             {
-                                "wins": 49,
-                                "losses": 32,
+                                "wins": 47,
+                                "losses": 34,
                                 "type": "home",
-                                "pct": ".605"
+                                "pct": ".580"
                             },
                             {
-                                "wins": 29,
-                                "losses": 52,
+                                "wins": 45,
+                                "losses": 36,
                                 "type": "away",
-                                "pct": ".358"
+                                "pct": ".556"
                             },
                             {
-                                "wins": 21,
-                                "losses": 25,
+                                "wins": 12,
+                                "losses": 20,
                                 "type": "left",
-                                "pct": ".457"
+                                "pct": ".375"
                             },
                             {
-                                "wins": 14,
-                                "losses": 8,
+                                "wins": 6,
+                                "losses": 10,
                                 "type": "leftHome",
-                                "pct": ".636"
+                                "pct": ".375"
                             },
                             {
-                                "wins": 7,
-                                "losses": 17,
+                                "wins": 6,
+                                "losses": 10,
                                 "type": "leftAway",
-                                "pct": ".292"
+                                "pct": ".375"
                             },
                             {
-                                "wins": 35,
+                                "wins": 41,
                                 "losses": 24,
                                 "type": "rightHome",
-                                "pct": ".593"
+                                "pct": ".631"
                             },
                             {
-                                "wins": 22,
-                                "losses": 35,
+                                "wins": 39,
+                                "losses": 26,
                                 "type": "rightAway",
-                                "pct": ".386"
+                                "pct": ".600"
                             },
                             {
-                                "wins": 57,
-                                "losses": 59,
+                                "wins": 80,
+                                "losses": 50,
                                 "type": "right",
-                                "pct": ".491"
+                                "pct": ".615"
                             },
                             {
                                 "wins": 7,
@@ -805,53 +337,53 @@
                                 "pct": ".700"
                             },
                             {
-                                "wins": 5,
-                                "losses": 8,
+                                "wins": 8,
+                                "losses": 7,
                                 "type": "extraInning",
-                                "pct": ".385"
+                                "pct": ".533"
                             },
                             {
-                                "wins": 15,
-                                "losses": 21,
+                                "wins": 30,
+                                "losses": 20,
                                 "type": "oneRun",
-                                "pct": ".417"
+                                "pct": ".600"
                             },
                             {
-                                "wins": 29,
-                                "losses": 47,
+                                "wins": 45,
+                                "losses": 49,
                                 "type": "winners",
-                                "pct": ".382"
+                                "pct": ".479"
                             },
                             {
-                                "wins": 31,
-                                "losses": 32,
+                                "wins": 35,
+                                "losses": 28,
                                 "type": "day",
-                                "pct": ".492"
+                                "pct": ".556"
                             },
                             {
-                                "wins": 47,
-                                "losses": 52,
+                                "wins": 57,
+                                "losses": 42,
                                 "type": "night",
-                                "pct": ".475"
+                                "pct": ".576"
                             },
                             {
-                                "wins": 74,
-                                "losses": 80,
+                                "wins": 39,
+                                "losses": 30,
                                 "type": "grass",
-                                "pct": ".481"
+                                "pct": ".565"
                             },
                             {
-                                "wins": 4,
-                                "losses": 4,
+                                "wins": 53,
+                                "losses": 40,
                                 "type": "turf",
-                                "pct": ".500"
+                                "pct": ".570"
                             }
                         ],
                         "divisionRecords": [
                             {
-                                "wins": 10,
-                                "losses": 22,
-                                "pct": ".313",
+                                "wins": 17,
+                                "losses": 15,
+                                "pct": ".531",
                                 "division": {
                                     "id": 200,
                                     "name": "American League West",
@@ -859,247 +391,13 @@
                                 }
                             },
                             {
-                                "wins": 18,
-                                "losses": 16,
-                                "pct": ".529",
+                                "wins": 43,
+                                "losses": 33,
+                                "pct": ".566",
                                 "division": {
                                     "id": 201,
                                     "name": "American League East",
                                     "link": "/api/v1/divisions/201"
-                                }
-                            },
-                            {
-                                "wins": 42,
-                                "losses": 34,
-                                "pct": ".553",
-                                "division": {
-                                    "id": 202,
-                                    "name": "American League Central",
-                                    "link": "/api/v1/divisions/202"
-                                }
-                            }
-                        ],
-                        "overallRecords": [
-                            {
-                                "wins": 49,
-                                "losses": 32,
-                                "type": "home",
-                                "pct": ".605"
-                            },
-                            {
-                                "wins": 29,
-                                "losses": 52,
-                                "type": "away",
-                                "pct": ".358"
-                            }
-                        ],
-                        "leagueRecords": [
-                            {
-                                "wins": 70,
-                                "losses": 72,
-                                "pct": ".493",
-                                "league": {
-                                    "id": 103,
-                                    "name": "American League",
-                                    "link": "/api/v1/league/103"
-                                }
-                            },
-                            {
-                                "wins": 8,
-                                "losses": 12,
-                                "pct": ".400",
-                                "league": {
-                                    "id": 104,
-                                    "name": "National League",
-                                    "link": "/api/v1/league/104"
-                                }
-                            }
-                        ],
-                        "expectedRecords": [
-                            {
-                                "wins": 77,
-                                "losses": 85,
-                                "type": "xWinLoss",
-                                "pct": ".475"
-                            },
-                            {
-                                "wins": 77,
-                                "losses": 85,
-                                "type": "xWinLossSeason",
-                                "pct": ".475"
-                            }
-                        ]
-                    },
-                    "runsAllowed": 775,
-                    "runsScored": 738,
-                    "divisionChamp": false,
-                    "divisionLeader": false,
-                    "hasWildcard": true,
-                    "clinched": false,
-                    "eliminationNumber": "E",
-                    "wildCardEliminationNumber": "E",
-                    "wins": 78,
-                    "losses": 84,
-                    "runDifferential": -37,
-                    "winningPercentage": ".481"
-                }
-            ]
-        },
-        {
-            "standingsType": "regularSeason",
-            "league": {
-                "id": 103,
-                "link": "/api/v1/league/103"
-            },
-            "division": {
-                "id": 200,
-                "link": "/api/v1/divisions/200"
-            },
-            "sport": {
-                "id": 1,
-                "link": "/api/v1/sports/1"
-            },
-            "lastUpdated": "2022-01-21T18:46:31.644Z",
-            "teamRecords": [
-                {
-                    "team": {
-                        "id": 117,
-                        "name": "Houston Astros",
-                        "link": "/api/v1/teams/117"
-                    },
-                    "season": "2018",
-                    "streak": {
-                        "streakType": "losses",
-                        "streakNumber": 1,
-                        "streakCode": "L1"
-                    },
-                    "clinchIndicator": "y",
-                    "divisionRank": "1",
-                    "leagueRank": "2",
-                    "sportRank": "2",
-                    "gamesPlayed": 162,
-                    "gamesBack": "-",
-                    "wildCardGamesBack": "-",
-                    "leagueGamesBack": "5.0",
-                    "springLeagueGamesBack": "-",
-                    "sportGamesBack": "5.0",
-                    "divisionGamesBack": "-",
-                    "conferenceGamesBack": "-",
-                    "leagueRecord": {
-                        "wins": 103,
-                        "losses": 59,
-                        "ties": 0,
-                        "pct": ".636"
-                    },
-                    "lastUpdated": "2021-11-23T01:32:01Z",
-                    "records": {
-                        "splitRecords": [
-                            {
-                                "wins": 46,
-                                "losses": 35,
-                                "type": "home",
-                                "pct": ".568"
-                            },
-                            {
-                                "wins": 57,
-                                "losses": 24,
-                                "type": "away",
-                                "pct": ".704"
-                            },
-                            {
-                                "wins": 37,
-                                "losses": 23,
-                                "type": "left",
-                                "pct": ".617"
-                            },
-                            {
-                                "wins": 13,
-                                "losses": 17,
-                                "type": "leftHome",
-                                "pct": ".433"
-                            },
-                            {
-                                "wins": 24,
-                                "losses": 6,
-                                "type": "leftAway",
-                                "pct": ".800"
-                            },
-                            {
-                                "wins": 33,
-                                "losses": 18,
-                                "type": "rightHome",
-                                "pct": ".647"
-                            },
-                            {
-                                "wins": 33,
-                                "losses": 18,
-                                "type": "rightAway",
-                                "pct": ".647"
-                            },
-                            {
-                                "wins": 66,
-                                "losses": 36,
-                                "type": "right",
-                                "pct": ".647"
-                            },
-                            {
-                                "wins": 8,
-                                "losses": 2,
-                                "type": "lastTen",
-                                "pct": ".800"
-                            },
-                            {
-                                "wins": 5,
-                                "losses": 6,
-                                "type": "extraInning",
-                                "pct": ".455"
-                            },
-                            {
-                                "wins": 24,
-                                "losses": 24,
-                                "type": "oneRun",
-                                "pct": ".500"
-                            },
-                            {
-                                "wins": 41,
-                                "losses": 38,
-                                "type": "winners",
-                                "pct": ".519"
-                            },
-                            {
-                                "wins": 34,
-                                "losses": 17,
-                                "type": "day",
-                                "pct": ".667"
-                            },
-                            {
-                                "wins": 69,
-                                "losses": 42,
-                                "type": "night",
-                                "pct": ".622"
-                            },
-                            {
-                                "wins": 100,
-                                "losses": 55,
-                                "type": "grass",
-                                "pct": ".645"
-                            },
-                            {
-                                "wins": 3,
-                                "losses": 4,
-                                "type": "turf",
-                                "pct": ".429"
-                            }
-                        ],
-                        "divisionRecords": [
-                            {
-                                "wins": 46,
-                                "losses": 30,
-                                "pct": ".605",
-                                "division": {
-                                    "id": 200,
-                                    "name": "American League West",
-                                    "link": "/api/v1/divisions/200"
                                 }
                             },
                             {
@@ -1107,16 +405,6 @@
                                 "losses": 15,
                                 "pct": ".559",
                                 "division": {
-                                    "id": 201,
-                                    "name": "American League East",
-                                    "link": "/api/v1/divisions/201"
-                                }
-                            },
-                            {
-                                "wins": 25,
-                                "losses": 7,
-                                "pct": ".781",
-                                "division": {
                                     "id": 202,
                                     "name": "American League Central",
                                     "link": "/api/v1/divisions/202"
@@ -1125,23 +413,23 @@
                         ],
                         "overallRecords": [
                             {
-                                "wins": 46,
-                                "losses": 35,
+                                "wins": 47,
+                                "losses": 34,
                                 "type": "home",
-                                "pct": ".568"
+                                "pct": ".580"
                             },
                             {
-                                "wins": 57,
-                                "losses": 24,
+                                "wins": 45,
+                                "losses": 36,
                                 "type": "away",
-                                "pct": ".704"
+                                "pct": ".556"
                             }
                         ],
                         "leagueRecords": [
                             {
-                                "wins": 90,
-                                "losses": 52,
-                                "pct": ".634",
+                                "wins": 79,
+                                "losses": 63,
+                                "pct": ".556",
                                 "league": {
                                     "id": 103,
                                     "name": "American League",
@@ -1161,120 +449,141 @@
                         ],
                         "expectedRecords": [
                             {
-                                "wins": 109,
-                                "losses": 53,
+                                "wins": 91,
+                                "losses": 71,
                                 "type": "xWinLoss",
-                                "pct": ".673"
+                                "pct": ".562"
                             },
                             {
-                                "wins": 109,
-                                "losses": 53,
+                                "wins": 91,
+                                "losses": 71,
                                 "type": "xWinLossSeason",
-                                "pct": ".673"
+                                "pct": ".562"
                             }
                         ]
                     },
-                    "runsAllowed": 534,
-                    "runsScored": 797,
-                    "divisionChamp": true,
-                    "divisionLeader": true,
+                    "runsAllowed": 679,
+                    "runsScored": 775,
+                    "divisionChamp": false,
+                    "divisionLeader": false,
+                    "wildCardLeader": true,
                     "hasWildcard": true,
                     "clinched": true,
-                    "eliminationNumber": "-",
+                    "eliminationNumber": "E",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "E",
+                    "eliminationNumberDivision": "E",
+                    "eliminationNumberConference": "90",
                     "wildCardEliminationNumber": "-",
-                    "magicNumber": "-",
-                    "wins": 103,
-                    "losses": 59,
-                    "runDifferential": 263,
-                    "winningPercentage": ".636"
-                },
+                    "wins": 92,
+                    "losses": 70,
+                    "runDifferential": 96,
+                    "winningPercentage": ".568"
+                }
+            ]
+        },
+        {
+            "standingsType": "regularSeason",
+            "league": {
+                "id": 103,
+                "link": "/api/v1/league/103"
+            },
+            "division": {
+                "id": 202,
+                "link": "/api/v1/divisions/202"
+            },
+            "sport": {
+                "id": 1,
+                "link": "/api/v1/sports/1"
+            },
+            "lastUpdated": "2023-06-03T16:19:43.302Z",
+            "teamRecords": [
                 {
                     "team": {
-                        "id": 133,
-                        "name": "Oakland Athletics",
-                        "link": "/api/v1/teams/133"
+                        "id": 114,
+                        "name": "Cleveland Guardians",
+                        "link": "/api/v1/teams/114"
                     },
-                    "season": "2018",
+                    "season": "2022",
                     "streak": {
-                        "streakType": "losses",
-                        "streakNumber": 1,
-                        "streakCode": "L1"
+                        "streakType": "wins",
+                        "streakNumber": 2,
+                        "streakCode": "W2"
                     },
-                    "clinchIndicator": "w",
-                    "divisionRank": "2",
-                    "leagueRank": "4",
-                    "wildCardRank": "2",
-                    "sportRank": "4",
+                    "clinchIndicator": "y",
+                    "divisionRank": "1",
+                    "leagueRank": "3",
+                    "sportRank": "3",
                     "gamesPlayed": 162,
-                    "gamesBack": "6.0",
+                    "gamesBack": "-",
                     "wildCardGamesBack": "-",
-                    "leagueGamesBack": "11.0",
+                    "leagueGamesBack": "14.0",
                     "springLeagueGamesBack": "-",
-                    "sportGamesBack": "11.0",
-                    "divisionGamesBack": "6.0",
+                    "sportGamesBack": "14.0",
+                    "divisionGamesBack": "-",
                     "conferenceGamesBack": "-",
                     "leagueRecord": {
-                        "wins": 97,
-                        "losses": 65,
+                        "wins": 92,
+                        "losses": 70,
                         "ties": 0,
-                        "pct": ".599"
+                        "pct": ".568"
                     },
-                    "lastUpdated": "2021-11-23T01:32:00Z",
+                    "lastUpdated": "2023-06-03T16:19:43Z",
                     "records": {
                         "splitRecords": [
                             {
-                                "wins": 50,
-                                "losses": 31,
+                                "wins": 46,
+                                "losses": 35,
                                 "type": "home",
-                                "pct": ".617"
+                                "pct": ".568"
                             },
                             {
-                                "wins": 47,
-                                "losses": 34,
+                                "wins": 46,
+                                "losses": 35,
                                 "type": "away",
-                                "pct": ".580"
+                                "pct": ".568"
+                            },
+                            {
+                                "wins": 28,
+                                "losses": 17,
+                                "type": "left",
+                                "pct": ".622"
+                            },
+                            {
+                                "wins": 14,
+                                "losses": 8,
+                                "type": "leftHome",
+                                "pct": ".636"
+                            },
+                            {
+                                "wins": 14,
+                                "losses": 9,
+                                "type": "leftAway",
+                                "pct": ".609"
                             },
                             {
                                 "wins": 32,
-                                "losses": 25,
-                                "type": "left",
-                                "pct": ".561"
-                            },
-                            {
-                                "wins": 15,
-                                "losses": 16,
-                                "type": "leftHome",
-                                "pct": ".484"
-                            },
-                            {
-                                "wins": 17,
-                                "losses": 9,
-                                "type": "leftAway",
-                                "pct": ".654"
-                            },
-                            {
-                                "wins": 35,
-                                "losses": 15,
+                                "losses": 27,
                                 "type": "rightHome",
-                                "pct": ".700"
+                                "pct": ".542"
                             },
                             {
-                                "wins": 30,
-                                "losses": 25,
+                                "wins": 32,
+                                "losses": 26,
                                 "type": "rightAway",
-                                "pct": ".545"
+                                "pct": ".552"
                             },
                             {
-                                "wins": 65,
-                                "losses": 40,
+                                "wins": 64,
+                                "losses": 53,
                                 "type": "right",
-                                "pct": ".619"
+                                "pct": ".547"
                             },
                             {
-                                "wins": 6,
-                                "losses": 4,
+                                "wins": 7,
+                                "losses": 3,
                                 "type": "lastTen",
-                                "pct": ".600"
+                                "pct": ".700"
                             },
                             {
                                 "wins": 13,
@@ -1283,47 +592,47 @@
                                 "pct": ".684"
                             },
                             {
-                                "wins": 31,
-                                "losses": 14,
+                                "wins": 28,
+                                "losses": 17,
                                 "type": "oneRun",
-                                "pct": ".689"
+                                "pct": ".622"
                             },
                             {
-                                "wins": 33,
-                                "losses": 40,
+                                "wins": 34,
+                                "losses": 34,
                                 "type": "winners",
-                                "pct": ".452"
+                                "pct": ".500"
                             },
                             {
-                                "wins": 37,
-                                "losses": 23,
+                                "wins": 40,
+                                "losses": 31,
                                 "type": "day",
-                                "pct": ".617"
+                                "pct": ".563"
                             },
                             {
-                                "wins": 60,
-                                "losses": 42,
+                                "wins": 52,
+                                "losses": 39,
                                 "type": "night",
-                                "pct": ".588"
+                                "pct": ".571"
                             },
                             {
-                                "wins": 92,
-                                "losses": 63,
+                                "wins": 85,
+                                "losses": 68,
                                 "type": "grass",
-                                "pct": ".594"
+                                "pct": ".556"
                             },
                             {
-                                "wins": 5,
+                                "wins": 7,
                                 "losses": 2,
                                 "type": "turf",
-                                "pct": ".714"
+                                "pct": ".778"
                             }
                         ],
                         "divisionRecords": [
                             {
-                                "wins": 38,
-                                "losses": 38,
-                                "pct": ".500",
+                                "wins": 18,
+                                "losses": 16,
+                                "pct": ".529",
                                 "division": {
                                     "id": 200,
                                     "name": "American League West",
@@ -1331,9 +640,9 @@
                                 }
                             },
                             {
-                                "wins": 21,
-                                "losses": 11,
-                                "pct": ".656",
+                                "wins": 15,
+                                "losses": 17,
+                                "pct": ".469",
                                 "division": {
                                     "id": 201,
                                     "name": "American League East",
@@ -1341,9 +650,9 @@
                                 }
                             },
                             {
-                                "wins": 26,
-                                "losses": 8,
-                                "pct": ".765",
+                                "wins": 47,
+                                "losses": 29,
+                                "pct": ".618",
                                 "division": {
                                     "id": 202,
                                     "name": "American League Central",
@@ -1353,23 +662,23 @@
                         ],
                         "overallRecords": [
                             {
-                                "wins": 50,
-                                "losses": 31,
+                                "wins": 46,
+                                "losses": 35,
                                 "type": "home",
-                                "pct": ".617"
+                                "pct": ".568"
                             },
                             {
-                                "wins": 47,
-                                "losses": 34,
+                                "wins": 46,
+                                "losses": 35,
                                 "type": "away",
-                                "pct": ".580"
+                                "pct": ".568"
                             }
                         ],
                         "leagueRecords": [
                             {
-                                "wins": 85,
-                                "losses": 57,
-                                "pct": ".599",
+                                "wins": 80,
+                                "losses": 62,
+                                "pct": ".563",
                                 "league": {
                                     "id": 103,
                                     "name": "American League",
@@ -1389,32 +698,747 @@
                         ],
                         "expectedRecords": [
                             {
-                                "wins": 95,
-                                "losses": 67,
+                                "wins": 88,
+                                "losses": 74,
                                 "type": "xWinLoss",
-                                "pct": ".586"
+                                "pct": ".543"
                             },
                             {
-                                "wins": 95,
-                                "losses": 67,
+                                "wins": 88,
+                                "losses": 74,
                                 "type": "xWinLossSeason",
-                                "pct": ".586"
+                                "pct": ".543"
                             }
                         ]
                     },
-                    "runsAllowed": 674,
-                    "runsScored": 813,
+                    "runsAllowed": 634,
+                    "runsScored": 698,
+                    "divisionChamp": true,
+                    "divisionLeader": true,
+                    "hasWildcard": true,
+                    "clinched": true,
+                    "eliminationNumber": "-",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "E",
+                    "eliminationNumberDivision": "-",
+                    "eliminationNumberConference": "90",
+                    "wildCardEliminationNumber": "-",
+                    "magicNumber": "-",
+                    "wins": 92,
+                    "losses": 70,
+                    "runDifferential": 64,
+                    "winningPercentage": ".568"
+                },
+                {
+                    "team": {
+                        "id": 145,
+                        "name": "Chicago White Sox",
+                        "link": "/api/v1/teams/145"
+                    },
+                    "season": "2022",
+                    "streak": {
+                        "streakType": "losses",
+                        "streakNumber": 1,
+                        "streakCode": "L1"
+                    },
+                    "divisionRank": "2",
+                    "leagueRank": "8",
+                    "wildCardRank": "5",
+                    "sportRank": "8",
+                    "gamesPlayed": 162,
+                    "gamesBack": "11.0",
+                    "wildCardGamesBack": "5.0",
+                    "leagueGamesBack": "25.0",
+                    "springLeagueGamesBack": "-",
+                    "sportGamesBack": "25.0",
+                    "divisionGamesBack": "11.0",
+                    "conferenceGamesBack": "-",
+                    "leagueRecord": {
+                        "wins": 81,
+                        "losses": 81,
+                        "ties": 0,
+                        "pct": ".500"
+                    },
+                    "lastUpdated": "2023-06-03T15:52:38Z",
+                    "records": {
+                        "splitRecords": [
+                            {
+                                "wins": 37,
+                                "losses": 44,
+                                "type": "home",
+                                "pct": ".457"
+                            },
+                            {
+                                "wins": 44,
+                                "losses": 37,
+                                "type": "away",
+                                "pct": ".543"
+                            },
+                            {
+                                "wins": 17,
+                                "losses": 20,
+                                "type": "left",
+                                "pct": ".459"
+                            },
+                            {
+                                "wins": 9,
+                                "losses": 11,
+                                "type": "leftHome",
+                                "pct": ".450"
+                            },
+                            {
+                                "wins": 8,
+                                "losses": 9,
+                                "type": "leftAway",
+                                "pct": ".471"
+                            },
+                            {
+                                "wins": 28,
+                                "losses": 33,
+                                "type": "rightHome",
+                                "pct": ".459"
+                            },
+                            {
+                                "wins": 36,
+                                "losses": 28,
+                                "type": "rightAway",
+                                "pct": ".563"
+                            },
+                            {
+                                "wins": 64,
+                                "losses": 61,
+                                "type": "right",
+                                "pct": ".512"
+                            },
+                            {
+                                "wins": 5,
+                                "losses": 5,
+                                "type": "lastTen",
+                                "pct": ".500"
+                            },
+                            {
+                                "wins": 6,
+                                "losses": 9,
+                                "type": "extraInning",
+                                "pct": ".400"
+                            },
+                            {
+                                "wins": 27,
+                                "losses": 16,
+                                "type": "oneRun",
+                                "pct": ".628"
+                            },
+                            {
+                                "wins": 31,
+                                "losses": 36,
+                                "type": "winners",
+                                "pct": ".463"
+                            },
+                            {
+                                "wins": 38,
+                                "losses": 32,
+                                "type": "day",
+                                "pct": ".543"
+                            },
+                            {
+                                "wins": 43,
+                                "losses": 49,
+                                "type": "night",
+                                "pct": ".467"
+                            },
+                            {
+                                "wins": 77,
+                                "losses": 75,
+                                "type": "grass",
+                                "pct": ".507"
+                            },
+                            {
+                                "wins": 4,
+                                "losses": 6,
+                                "type": "turf",
+                                "pct": ".400"
+                            }
+                        ],
+                        "divisionRecords": [
+                            {
+                                "wins": 18,
+                                "losses": 16,
+                                "pct": ".529",
+                                "division": {
+                                    "id": 200,
+                                    "name": "American League West",
+                                    "link": "/api/v1/divisions/200"
+                                }
+                            },
+                            {
+                                "wins": 15,
+                                "losses": 17,
+                                "pct": ".469",
+                                "division": {
+                                    "id": 201,
+                                    "name": "American League East",
+                                    "link": "/api/v1/divisions/201"
+                                }
+                            },
+                            {
+                                "wins": 37,
+                                "losses": 39,
+                                "pct": ".487",
+                                "division": {
+                                    "id": 202,
+                                    "name": "American League Central",
+                                    "link": "/api/v1/divisions/202"
+                                }
+                            }
+                        ],
+                        "overallRecords": [
+                            {
+                                "wins": 37,
+                                "losses": 44,
+                                "type": "home",
+                                "pct": ".457"
+                            },
+                            {
+                                "wins": 44,
+                                "losses": 37,
+                                "type": "away",
+                                "pct": ".543"
+                            }
+                        ],
+                        "leagueRecords": [
+                            {
+                                "wins": 70,
+                                "losses": 72,
+                                "pct": ".493",
+                                "league": {
+                                    "id": 103,
+                                    "name": "American League",
+                                    "link": "/api/v1/league/103"
+                                }
+                            },
+                            {
+                                "wins": 11,
+                                "losses": 9,
+                                "pct": ".550",
+                                "league": {
+                                    "id": 104,
+                                    "name": "National League",
+                                    "link": "/api/v1/league/104"
+                                }
+                            }
+                        ],
+                        "expectedRecords": [
+                            {
+                                "wins": 78,
+                                "losses": 84,
+                                "type": "xWinLoss",
+                                "pct": ".481"
+                            },
+                            {
+                                "wins": 78,
+                                "losses": 84,
+                                "type": "xWinLossSeason",
+                                "pct": ".481"
+                            }
+                        ]
+                    },
+                    "runsAllowed": 717,
+                    "runsScored": 686,
+                    "divisionChamp": false,
+                    "divisionLeader": false,
+                    "hasWildcard": true,
+                    "clinched": false,
+                    "eliminationNumber": "E",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "E",
+                    "eliminationNumberDivision": "E",
+                    "eliminationNumberConference": "79",
+                    "wildCardEliminationNumber": "E",
+                    "wins": 81,
+                    "losses": 81,
+                    "runDifferential": -31,
+                    "winningPercentage": ".500"
+                }
+            ]
+        },
+        {
+            "standingsType": "regularSeason",
+            "league": {
+                "id": 103,
+                "link": "/api/v1/league/103"
+            },
+            "division": {
+                "id": 200,
+                "link": "/api/v1/divisions/200"
+            },
+            "sport": {
+                "id": 1,
+                "link": "/api/v1/sports/1"
+            },
+            "lastUpdated": "2023-06-03T16:19:40.069Z",
+            "teamRecords": [
+                {
+                    "team": {
+                        "id": 117,
+                        "name": "Houston Astros",
+                        "link": "/api/v1/teams/117"
+                    },
+                    "season": "2022",
+                    "streak": {
+                        "streakType": "wins",
+                        "streakNumber": 2,
+                        "streakCode": "W2"
+                    },
+                    "clinchIndicator": "z",
+                    "divisionRank": "1",
+                    "leagueRank": "1",
+                    "sportRank": "1",
+                    "gamesPlayed": 162,
+                    "gamesBack": "-",
+                    "wildCardGamesBack": "-",
+                    "leagueGamesBack": "-",
+                    "springLeagueGamesBack": "-",
+                    "sportGamesBack": "-",
+                    "divisionGamesBack": "-",
+                    "conferenceGamesBack": "-",
+                    "leagueRecord": {
+                        "wins": 106,
+                        "losses": 56,
+                        "ties": 0,
+                        "pct": ".654"
+                    },
+                    "lastUpdated": "2023-06-03T15:41:25Z",
+                    "records": {
+                        "splitRecords": [
+                            {
+                                "wins": 55,
+                                "losses": 26,
+                                "type": "home",
+                                "pct": ".679"
+                            },
+                            {
+                                "wins": 51,
+                                "losses": 30,
+                                "type": "away",
+                                "pct": ".630"
+                            },
+                            {
+                                "wins": 42,
+                                "losses": 12,
+                                "type": "left",
+                                "pct": ".778"
+                            },
+                            {
+                                "wins": 23,
+                                "losses": 6,
+                                "type": "leftHome",
+                                "pct": ".793"
+                            },
+                            {
+                                "wins": 19,
+                                "losses": 6,
+                                "type": "leftAway",
+                                "pct": ".760"
+                            },
+                            {
+                                "wins": 32,
+                                "losses": 20,
+                                "type": "rightHome",
+                                "pct": ".615"
+                            },
+                            {
+                                "wins": 32,
+                                "losses": 24,
+                                "type": "rightAway",
+                                "pct": ".571"
+                            },
+                            {
+                                "wins": 64,
+                                "losses": 44,
+                                "type": "right",
+                                "pct": ".593"
+                            },
+                            {
+                                "wins": 7,
+                                "losses": 3,
+                                "type": "lastTen",
+                                "pct": ".700"
+                            },
+                            {
+                                "wins": 5,
+                                "losses": 6,
+                                "type": "extraInning",
+                                "pct": ".455"
+                            },
+                            {
+                                "wins": 28,
+                                "losses": 16,
+                                "type": "oneRun",
+                                "pct": ".636"
+                            },
+                            {
+                                "wins": 42,
+                                "losses": 27,
+                                "type": "winners",
+                                "pct": ".609"
+                            },
+                            {
+                                "wins": 42,
+                                "losses": 13,
+                                "type": "day",
+                                "pct": ".764"
+                            },
+                            {
+                                "wins": 64,
+                                "losses": 43,
+                                "type": "night",
+                                "pct": ".598"
+                            },
+                            {
+                                "wins": 94,
+                                "losses": 51,
+                                "type": "grass",
+                                "pct": ".648"
+                            },
+                            {
+                                "wins": 12,
+                                "losses": 5,
+                                "type": "turf",
+                                "pct": ".706"
+                            }
+                        ],
+                        "divisionRecords": [
+                            {
+                                "wins": 51,
+                                "losses": 25,
+                                "pct": ".671",
+                                "division": {
+                                    "id": 200,
+                                    "name": "American League West",
+                                    "link": "/api/v1/divisions/200"
+                                }
+                            },
+                            {
+                                "wins": 17,
+                                "losses": 15,
+                                "pct": ".531",
+                                "division": {
+                                    "id": 201,
+                                    "name": "American League East",
+                                    "link": "/api/v1/divisions/201"
+                                }
+                            },
+                            {
+                                "wins": 26,
+                                "losses": 8,
+                                "pct": ".765",
+                                "division": {
+                                    "id": 202,
+                                    "name": "American League Central",
+                                    "link": "/api/v1/divisions/202"
+                                }
+                            }
+                        ],
+                        "overallRecords": [
+                            {
+                                "wins": 55,
+                                "losses": 26,
+                                "type": "home",
+                                "pct": ".679"
+                            },
+                            {
+                                "wins": 51,
+                                "losses": 30,
+                                "type": "away",
+                                "pct": ".630"
+                            }
+                        ],
+                        "leagueRecords": [
+                            {
+                                "wins": 94,
+                                "losses": 48,
+                                "pct": ".662",
+                                "league": {
+                                    "id": 103,
+                                    "name": "American League",
+                                    "link": "/api/v1/league/103"
+                                }
+                            },
+                            {
+                                "wins": 12,
+                                "losses": 8,
+                                "pct": ".600",
+                                "league": {
+                                    "id": 104,
+                                    "name": "National League",
+                                    "link": "/api/v1/league/104"
+                                }
+                            }
+                        ],
+                        "expectedRecords": [
+                            {
+                                "wins": 106,
+                                "losses": 56,
+                                "type": "xWinLoss",
+                                "pct": ".654"
+                            },
+                            {
+                                "wins": 106,
+                                "losses": 56,
+                                "type": "xWinLossSeason",
+                                "pct": ".654"
+                            }
+                        ]
+                    },
+                    "runsAllowed": 518,
+                    "runsScored": 737,
+                    "divisionChamp": true,
+                    "divisionLeader": true,
+                    "hasWildcard": true,
+                    "clinched": true,
+                    "eliminationNumber": "-",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "-",
+                    "eliminationNumberDivision": "-",
+                    "eliminationNumberConference": "104",
+                    "wildCardEliminationNumber": "-",
+                    "magicNumber": "-",
+                    "wins": 106,
+                    "losses": 56,
+                    "runDifferential": 219,
+                    "winningPercentage": ".654"
+                },
+                {
+                    "team": {
+                        "id": 136,
+                        "name": "Seattle Mariners",
+                        "link": "/api/v1/teams/136"
+                    },
+                    "season": "2022",
+                    "streak": {
+                        "streakType": "wins",
+                        "streakNumber": 3,
+                        "streakCode": "W3"
+                    },
+                    "clinchIndicator": "w",
+                    "divisionRank": "2",
+                    "leagueRank": "5",
+                    "wildCardRank": "2",
+                    "sportRank": "5",
+                    "gamesPlayed": 162,
+                    "gamesBack": "16.0",
+                    "wildCardGamesBack": "+4.0",
+                    "leagueGamesBack": "16.0",
+                    "springLeagueGamesBack": "-",
+                    "sportGamesBack": "16.0",
+                    "divisionGamesBack": "16.0",
+                    "conferenceGamesBack": "-",
+                    "leagueRecord": {
+                        "wins": 90,
+                        "losses": 72,
+                        "ties": 0,
+                        "pct": ".556"
+                    },
+                    "lastUpdated": "2023-06-03T15:44:15Z",
+                    "records": {
+                        "splitRecords": [
+                            {
+                                "wins": 46,
+                                "losses": 35,
+                                "type": "home",
+                                "pct": ".568"
+                            },
+                            {
+                                "wins": 44,
+                                "losses": 37,
+                                "type": "away",
+                                "pct": ".543"
+                            },
+                            {
+                                "wins": 22,
+                                "losses": 20,
+                                "type": "left",
+                                "pct": ".524"
+                            },
+                            {
+                                "wins": 11,
+                                "losses": 11,
+                                "type": "leftHome",
+                                "pct": ".500"
+                            },
+                            {
+                                "wins": 11,
+                                "losses": 9,
+                                "type": "leftAway",
+                                "pct": ".550"
+                            },
+                            {
+                                "wins": 35,
+                                "losses": 24,
+                                "type": "rightHome",
+                                "pct": ".593"
+                            },
+                            {
+                                "wins": 33,
+                                "losses": 28,
+                                "type": "rightAway",
+                                "pct": ".541"
+                            },
+                            {
+                                "wins": 68,
+                                "losses": 52,
+                                "type": "right",
+                                "pct": ".567"
+                            },
+                            {
+                                "wins": 7,
+                                "losses": 3,
+                                "type": "lastTen",
+                                "pct": ".700"
+                            },
+                            {
+                                "wins": 11,
+                                "losses": 5,
+                                "type": "extraInning",
+                                "pct": ".688"
+                            },
+                            {
+                                "wins": 34,
+                                "losses": 22,
+                                "type": "oneRun",
+                                "pct": ".607"
+                            },
+                            {
+                                "wins": 38,
+                                "losses": 33,
+                                "type": "winners",
+                                "pct": ".535"
+                            },
+                            {
+                                "wins": 37,
+                                "losses": 27,
+                                "type": "day",
+                                "pct": ".578"
+                            },
+                            {
+                                "wins": 53,
+                                "losses": 45,
+                                "type": "night",
+                                "pct": ".541"
+                            },
+                            {
+                                "wins": 80,
+                                "losses": 63,
+                                "type": "grass",
+                                "pct": ".559"
+                            },
+                            {
+                                "wins": 10,
+                                "losses": 9,
+                                "type": "turf",
+                                "pct": ".526"
+                            }
+                        ],
+                        "divisionRecords": [
+                            {
+                                "wins": 41,
+                                "losses": 35,
+                                "pct": ".539",
+                                "division": {
+                                    "id": 200,
+                                    "name": "American League West",
+                                    "link": "/api/v1/divisions/200"
+                                }
+                            },
+                            {
+                                "wins": 16,
+                                "losses": 17,
+                                "pct": ".485",
+                                "division": {
+                                    "id": 201,
+                                    "name": "American League East",
+                                    "link": "/api/v1/divisions/201"
+                                }
+                            },
+                            {
+                                "wins": 21,
+                                "losses": 12,
+                                "pct": ".636",
+                                "division": {
+                                    "id": 202,
+                                    "name": "American League Central",
+                                    "link": "/api/v1/divisions/202"
+                                }
+                            }
+                        ],
+                        "overallRecords": [
+                            {
+                                "wins": 46,
+                                "losses": 35,
+                                "type": "home",
+                                "pct": ".568"
+                            },
+                            {
+                                "wins": 44,
+                                "losses": 37,
+                                "type": "away",
+                                "pct": ".543"
+                            }
+                        ],
+                        "leagueRecords": [
+                            {
+                                "wins": 78,
+                                "losses": 64,
+                                "pct": ".549",
+                                "league": {
+                                    "id": 103,
+                                    "name": "American League",
+                                    "link": "/api/v1/league/103"
+                                }
+                            },
+                            {
+                                "wins": 12,
+                                "losses": 8,
+                                "pct": ".600",
+                                "league": {
+                                    "id": 104,
+                                    "name": "National League",
+                                    "link": "/api/v1/league/104"
+                                }
+                            }
+                        ],
+                        "expectedRecords": [
+                            {
+                                "wins": 89,
+                                "losses": 73,
+                                "type": "xWinLoss",
+                                "pct": ".549"
+                            },
+                            {
+                                "wins": 89,
+                                "losses": 73,
+                                "type": "xWinLossSeason",
+                                "pct": ".549"
+                            }
+                        ]
+                    },
+                    "runsAllowed": 623,
+                    "runsScored": 690,
                     "divisionChamp": false,
                     "divisionLeader": false,
                     "wildCardLeader": true,
                     "hasWildcard": true,
                     "clinched": true,
                     "eliminationNumber": "E",
+                    "eliminationNumberSport": "E",
+                    "eliminationNumberLeague": "E",
+                    "eliminationNumberDivision": "E",
+                    "eliminationNumberConference": "88",
                     "wildCardEliminationNumber": "-",
-                    "wins": 97,
-                    "losses": 65,
-                    "runDifferential": 139,
-                    "winningPercentage": ".599"
+                    "wins": 90,
+                    "losses": 72,
+                    "runDifferential": 67,
+                    "winningPercentage": ".556"
                 }
             ]
         }


### PR DESCRIPTION
### Why

Fixes Issue #194 and Issue #195

### What

Standings model attribute Teamrecords was updated to include 
```
eliminationnumbersport: str
eliminationnumberleague: str
eliminationnumberdivision: str
eliminationnumberconference: str
```
Which were missing due to an update with the mlb api. 
Mock_json test json file was also updated to reflect these updates.

Game model livedata/boxscore attribute PlayersDictPerson was updated to make position optional
```
position: Optional[Union[Position, dict]] = None

|

self.position = Position(**self.position) if self.position else self.position
```
This was made optional due to a Tyler Brown playing for Minnesota in gameid 719391 not having a position attribute. 

### Tests

Live + mocktests updated and ran. Both pass 100%

### Risk and impact

Normal risk, normal impact. 
