### PR TITLE
Fixes Issue #216 parentteamid player attribute issue

### DIFF
--- a/mlbstatsapi/models/people/people.py
+++ b/mlbstatsapi/models/people/people.py
@@ -181,8 +181,8 @@ class Player(Person):
     parentteamid : int
         parent team id        
     """
+    parentteamid: Optional[int] = None
     jerseynumber: str
-    parentteamid: int
     position: InitVar[dict]
     status: Union[Status, dict]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.22"
+version = "0.5.23"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },


### PR DESCRIPTION
### Why

Issue with Michael Mercado not having a parent team id present in his roster information.

### What

 This fixes that issue by making the parentteamid attribute for the Player class optional.

### Tests

Tests ran and passed

### Risk and impact

- Minimal