### PR TITLE
Update hitting.py to fix unexpected keyword errors

### DIFF
--- a/mlbstatsapi/models/stats/hitting.py
+++ b/mlbstatsapi/models/stats/hitting.py
@@ -248,6 +248,15 @@ class SimpleHittingSplit:
     catchersinterference: Optional[int] = None
     atbatsperhomerun: Optional[int] = None
 
+    def __init__(self, **kwargs):
+        # Assign only known attributes to the class
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                # Log or handle unexpected attributes
+                print(f"Warning: Unexpected attribute '{key}' with value '{value}' ignored.")
+
     def __repr__(self) -> str:
         kws = [f'{key}={value}' for key, value in self.__dict__.items() if value is not None]
         return "{}({})".format(type(self).__name__, ", ".join(kws))


### PR DESCRIPTION
### Why


Running this code with 'gameLog', which is a valid stat input was giving an unexpected keyword summary exception:
```
    stats = ['gameLog']
    groups = ['hitting']
    params = {'season': 2024}
    all_game_stats = mlb.get_player_stats(664034, stats, groups, **params)
```


### What


Changes were made to ignore unexpected keywords instead of throwing an error


### Tests


Tested with original library code calls and now it is working 


