### PR TITLE
Fix SimplePitchingSplit error: Add missing age and caughtstealingpercentage fields

### DIFF
--- a/mlbstatsapi/models/stats/pitching.py
+++ b/mlbstatsapi/models/stats/pitching.py
@@ -150,6 +150,8 @@ class SimplePitchingSplit:
         The number of inherited runners scored by the pitcher.
     inheritedrunners : int
         The number of inherited runners for the pitcher.
+    age : int
+        The age of the pitcher.
     """
     summary: Optional[str] = None
     gamesplayed: Optional[int] = None
@@ -216,6 +218,8 @@ class SimplePitchingSplit:
     balls: Optional[int] = None
     outspitched: Optional[int] = None
     rbi: Optional[int] = None
+    age: Optional[int] = None
+    caughtstealingpercentage: Optional[str] = None
 
     def __repr__(self) -> str:
         kws = [f'{key}={value}' for key, value in self.__dict__.items() if value is not None and value]


### PR DESCRIPTION
## Summary
- Fixes missing `age` and `caughtstealingpercentage` fields in SimplePitchingSplit dataclass
- Resolves TypeError when MLB API returns these new fields in pitcher statistics
- Addresses issue #232

## Changes Made
- Added `age: Optional[int] = None` to SimplePitchingSplit
- Added `caughtstealingpercentage: Optional[str] = None` to SimplePitchingSplit
- Updated docstring to document the new age field

## Testing
- Verified fix works with player ID 641793 (consistently reproduced the issue)
- No breaking changes to existing functionality
- All new fields are optional to maintain backward compatibility

## Background  
The MLB API has added new statistical fields to pitcher data responses. The existing SimplePitchingSplit dataclass was missing these fields, causing crashes when processing current API responses.

🤖 Generated with [Claude Code](https://claude.ai/code)